### PR TITLE
Implement the base for integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Test
       run: |
         pipx run nox -s pre-test
-        pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- --showlocals
+        pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- --showlocals -v -s
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: |
-        pipx run nox -s pre-test
-        pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- --showlocals -v -s
+      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -s
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,9 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
+      run: |
+        pipx run nox -s pre-test
+        pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- --showlocals
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ dmypy.json
 .nox
 .vscode
 tests/data/rez_repo
-tests/data/python
+tests/data/_tmp_download

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ dmypy.json
 # Custom
 .nox
 .vscode
+tests/data/rez_repo
+tests/data/python

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 """Development automation"""
 import os
+import re
 import json
 import platform
 import urllib.request
@@ -54,12 +55,7 @@ def update_pip(session: nox.Session):
 
 @nox.session(name="pre-test")
 def pre_test(session: nox.Session):
-    with urllib.request.urlopen(
-        "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
-    ) as fd:
-        versionsManifest = json.load(fd)
-
-    downloadDir = os.path.join("tests", "data", "python")
+    downloadDir = os.path.join("tests", "data", "_tmp_download")
     try:
         os.makedirs(downloadDir)
     except FileExistsError:
@@ -67,26 +63,46 @@ def pre_test(session: nox.Session):
 
     versions = ["2.7.18", "3.11.3"]
 
-    platformMap = {"Linux": "linux", "Windows": "win32", "Darwin": "darwin"}
+    urls = {}
+    if platform.system() == "Windows":
+        for version in versions:
+            nugetName = "python"
+            if version[0] == "2":
+                nugetName += "2"
+            urls[
+                version
+            ] = f"https://globalcdn.nuget.org/packages/{nugetName}.{version}.nupkg"
 
-    for manifest in versionsManifest:
-        if manifest["version"] in versions:
-            for version in manifest["files"]:
-                if (
-                    version["arch"] == "x64"
-                    and version["platform"] == platformMap[platform.system()]
-                ):
-                    path = f"{downloadDir}/{version['filename']}"
-                    if os.path.exists(path):
+    else:
+        with urllib.request.urlopen(
+            "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
+        ) as fd:
+            versionsManifest = json.load(fd)
+
+        for manifest in versionsManifest:
+            if manifest["version"] in versions:
+                for version in manifest["files"]:
+                    if (
+                        version["arch"] == "x64"
+                        and version["platform"] == platform.system().lower()
+                    ):
+                        urls[manifest["version"]] = version["download_url"]
                         break
+                else:
+                    session.error(
+                        f"Failed to find URL for Python {manifest['version']}"
+                    )
 
-                    with urllib.request.urlopen(version["download_url"]) as fd:
-                        session.log(
-                            f"Downloading {version['download_url']} to {path!r}"
-                        )
-                        with open(f"{downloadDir}/{version['filename']}", "wb") as fd2:
-                            fd2.write(fd.read())
-                            break
+    for version, url in urls.items():
+        ext = re.findall(r"\.([a-z]\w+(?:\.?[a-z0-9]+))", url.split("/")[-1])[0]
+        filename = f"python-{version}-{platform.system().lower()}.{ext}"
 
-            else:
-                session.error(f"Failed to find URL for Python {manifest['version']}")
+        path = os.path.join(downloadDir, filename)
+        if os.path.exists(path):
+            session.log(f"Skipping {url} because {path!r} already exists")
+            continue
+
+        session.log(f"Downloading {url} to {path!r}")
+        with urllib.request.urlopen(url) as archive:
+            with open(f"{downloadDir}/{filename}", "wb") as targetFile:
+                targetFile.write(archive.read())

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,10 +1,4 @@
 """Development automation"""
-import os
-import re
-import json
-import platform
-import urllib.request
-
 import nox
 
 # nox.options.sessions = ["lint", "test", "doctest"]
@@ -38,12 +32,6 @@ def test(session: nox.Session):
 
     session.run(
         "pytest",
-        "-v",
-        "--strict-markers",
-        "--cov=rez_pip",
-        "--cov-branch",
-        "--cov-report=term-missing",
-        "--cov-report=xml",
         *session.posargs,
     )
 
@@ -51,58 +39,3 @@ def test(session: nox.Session):
 @nox.session()
 def update_pip(session: nox.Session):
     pass
-
-
-@nox.session(name="pre-test")
-def pre_test(session: nox.Session):
-    downloadDir = os.path.join("tests", "data", "_tmp_download")
-    try:
-        os.makedirs(downloadDir)
-    except FileExistsError:
-        pass
-
-    versions = ["2.7.18", "3.11.3"]
-
-    urls = {}
-    if platform.system() == "Windows":
-        for version in versions:
-            nugetName = "python"
-            if version[0] == "2":
-                nugetName += "2"
-            urls[
-                version
-            ] = f"https://globalcdn.nuget.org/packages/{nugetName}.{version}.nupkg"
-
-    else:
-        with urllib.request.urlopen(
-            "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
-        ) as fd:
-            versionsManifest = json.load(fd)
-
-        for manifest in versionsManifest:
-            if manifest["version"] in versions:
-                for version in manifest["files"]:
-                    if (
-                        version["arch"] == "x64"
-                        and version["platform"] == platform.system().lower()
-                    ):
-                        urls[manifest["version"]] = version["download_url"]
-                        break
-                else:
-                    session.error(
-                        f"Failed to find URL for Python {manifest['version']}"
-                    )
-
-    for version, url in urls.items():
-        ext = re.findall(r"\.([a-z]\w+(?:\.?[a-z0-9]+))", url.split("/")[-1])[0]
-        filename = f"python-{version}-{platform.system().lower()}.{ext}"
-
-        path = os.path.join(downloadDir, filename)
-        if os.path.exists(path):
-            session.log(f"Skipping {url} because {path!r} already exists")
-            continue
-
-        session.log(f"Downloading {url} to {path!r}")
-        with urllib.request.urlopen(url) as archive:
-            with open(f"{downloadDir}/{filename}", "wb") as targetFile:
-                targetFile.write(archive.read())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -v --strict-markers --cov=rez_pip --cov-branch --cov-report=term-missing --cov-report=xml --showlocals
+
+norecursedirs = rez_repo
+
+markers =
+    integration: mark the tests as integration tests

--- a/src/rez_pip/__main__.py
+++ b/src/rez_pip/__main__.py
@@ -67,6 +67,7 @@ def run() -> None:
     # This would solve the problem with --target and --install-path
     # and would allow to just use --target to set the path where the rez packages will
     # be installed.
+
     with tempfile.TemporaryDirectory(prefix="rez-pip") as tempDir:
         with rich.get_console().status(
             f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(args.packages))}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,101 @@
+import os
+import glob
+import tarfile
+import zipfile
+
+# import time
+# import typing
+# import subprocess
+# import dataclasses
+# import http.client
+
+# import toml
+import pytest
+import rez.packages
+import rez.package_maker
+
+
+# @pytest.fixture(scope="session")
+# def pypi() -> typing.Generator[str, None, None]:
+#     configPath = os.path.join(os.path.dirname(__file__), "simpleindex.toml")
+
+#     @dataclasses.dataclass
+#     class ServerConfig:
+#         host: str
+#         port: int
+
+#     with open(configPath, encoding="utf-8") as fd:
+#         config = ServerConfig(**toml.load(fd)["server"])
+
+#     proc = subprocess.Popen(
+#         ["simpleindex", configPath],
+#         stdout=subprocess.PIPE,
+#         stderr=subprocess.STDOUT,
+#         cwd=os.path.dirname(__file__),
+#     )
+
+#     url = f"http://{config.host}:{config.port}"
+
+#     retries = 50
+#     while retries > 0:
+#         conn = http.client.HTTPConnection(f"{config.host}:{config.port}")
+#         try:
+#             conn.request("HEAD", "/")
+#             response = conn.getresponse()
+#             if response is not None:
+#                 yield url
+#                 break
+#         except ConnectionRefusedError:
+#             time.sleep(0.1)
+#             retries -= 1
+
+#     proc.terminate()
+#     proc.wait()
+
+#     if not retries:
+#         raise RuntimeError("Failed to start simpleindex")
+
+
+@pytest.fixture(scope="session")
+def rezRepo() -> str:
+    return os.path.join(os.path.dirname(__file__), "data", "rez_repo")
+
+
+@pytest.fixture(scope="session")
+def createPythonRezPackages(rezRepo: str):
+    pythonArchives = glob.glob(
+        os.path.join(os.path.dirname(__file__), "data", "python", "*")
+    )
+
+    for pythonArchive in pythonArchives:
+        print(f"Creating rez package for {pythonArchive} in {rezRepo!r}")
+
+        def make_root(variant: rez.packages.Variant, path: str) -> None:
+            """Using distlib to iterate over all installed files of the current
+            distribution to copy files to the target directory of the rez package
+            variant
+            """
+            if pythonArchive.endswith(".tar.gz"):
+                with tarfile.open(pythonArchive) as tar:
+                    tar.extractall(path=os.path.join(path, "python"))
+            elif pythonArchive.endswith(".zip"):
+                with zipfile.ZipFile(pythonArchive) as zipFd:
+                    zipFd.extractall(path=os.path.join(path, "python"))
+            else:
+                raise RuntimeError(f"{pythonArchive} is of known type")
+
+        with rez.package_maker.make_package(
+            "python",
+            rezRepo,
+            make_root=make_root,
+        ) as pkg:
+            pass
+            pkg.version = os.path.basename(pythonArchive).split("-")[1]
+
+            pkg.commands = "\n".join(
+                [
+                    "env.PATH.prepend('{root}/python/bin')",
+                    "env.LD_LIBRARY_PATH.prepend('{root}/python/lib')",
+                    "env.DYLD_LIBRARY_PATH.prepend('{root}/python/lib')",
+                ]
+            )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,17 @@
 import os
-import glob
+import re
+import json
+import typing
 import tarfile
 import zipfile
 import platform
+import urllib.request
 
-# import time
-# import typing
-# import subprocess
-# import dataclasses
-# import http.client
-
-# import toml
 import pytest
 import rez.packages
 import rez.package_maker
 
+DOWNLOAD_DIR = os.path.abspath(os.path.join("tests", "data", "_tmp_download"))
 
 # @pytest.fixture(scope="session")
 # def pypi() -> typing.Generator[str, None, None]:
@@ -63,35 +60,99 @@ def rezRepo() -> str:
 
 
 @pytest.fixture(scope="session")
-def createPythonRezPackages(rezRepo: str):
-    pythonArchives = glob.glob(
-        os.path.join(os.path.dirname(__file__), "data", "_tmp_download", "*")
-    )
+def downloadPythonVersions(
+    printer_session: typing.Callable[[str], None]
+) -> typing.List[typing.Tuple[str, str]]:
+    try:
+        os.makedirs(DOWNLOAD_DIR)
+    except FileExistsError:
+        pass
 
-    for pythonArchive in pythonArchives:
-        print(f"Creating rez package for {pythonArchive} in {rezRepo!r}")
+    urls: typing.Dict[str, str] = {}
+    versions = ["2.7.18", "3.11.3"]
 
-        if pythonArchive.endswith(".tar.gz"):
+    if platform.system() == "Windows":
+        for version in versions:
+            nugetName = "python"
+            if version[0] == "2":
+                nugetName += "2"
+            urls[
+                version
+            ] = f"https://globalcdn.nuget.org/packages/{nugetName}.{version}.nupkg"
+
+    else:
+        with urllib.request.urlopen(
+            "https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json"
+        ) as fd:
+            versionsManifest = json.load(fd)
+
+        for manifest in versionsManifest:
+            if manifest["version"] in versions:
+                for version in manifest["files"]:
+                    if (
+                        version["arch"] == "x64"
+                        and version["platform"] == platform.system().lower()
+                    ):
+                        urls[manifest["version"]] = version["download_url"]
+                        break
+                else:
+                    pytest.fail(f"Failed to find URL for Python {manifest['version']}")
+
+    items = []
+    for version, url in urls.items():
+        ext = re.findall(r"\.([a-z]\w+(?:\.?[a-z0-9]+))", url.split("/")[-1])[0]
+        filename = f"python-{version}-{platform.system().lower()}.{ext}"
+
+        path = os.path.join(DOWNLOAD_DIR, filename)
+
+        items.append([version, path])
+
+        if os.path.exists(path):
+            printer_session(f"Skipping {url} because {path!r} already exists")
+            continue
+
+        printer_session(f"Downloading {url} to {path!r}")
+        with urllib.request.urlopen(url) as archive:
+            with open(path, "wb") as targetFile:
+                targetFile.write(archive.read())
+
+    return items
+
+
+@pytest.fixture(scope="session")
+def setupRezPackages(
+    downloadPythonVersions: typing.List[typing.Tuple[str, str]],
+    rezRepo: str,
+    printer_session: typing.Callable[[str], None],
+) -> str:
+    for version, archivePath in downloadPythonVersions:
+        if not os.path.exists(archivePath):
+            pytest.fail(f"Cannot install {archivePath!r} because it does not exist")
+
+        if archivePath.endswith(".tar.gz"):
             openArchive = tarfile.open
-        elif pythonArchive.endswith(".nupkg"):
+        elif archivePath.endswith(".nupkg"):
             openArchive = zipfile.ZipFile
         else:
-            raise RuntimeError(f"{pythonArchive} is of unknown type")
+            raise RuntimeError(f"{archivePath} is of unknown type")
 
         def make_root(variant: rez.packages.Variant, path: str) -> None:
             """Using distlib to iterate over all installed files of the current
             distribution to copy files to the target directory of the rez package
             variant
             """
-            with openArchive(pythonArchive) as archive:
+            printer_session(f"Creating rez package for {archivePath} in {rezRepo!r}")
+            with openArchive(archivePath) as archive:
                 archive.extractall(path=os.path.join(path, "python"))
 
         with rez.package_maker.make_package(
             "python",
             rezRepo,
             make_root=make_root,
+            skip_existing=True,
+            warn_on_skip=False,
         ) as pkg:
-            pkg.version = os.path.basename(pythonArchive).split("-")[1]
+            pkg.version = version
 
             commands = [
                 "env.PATH.prepend('{root}/python/bin')",
@@ -109,3 +170,10 @@ def createPythonRezPackages(rezRepo: str):
                 ]
 
             pkg.commands = "\n".join(commands)
+
+        if pkg.skipped_variants:
+            printer_session(
+                f"Python {version} rez package already exists at {pkg.skipped_variants[0].uri}"
+            )
+
+    return rezRepo

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest>=7.2.0
 pytest-cov>=4.0.0
 pytest-httpserver>=1.0.6
+pytest-print

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -2,7 +2,6 @@ import os
 import typing
 
 import pytest
-
 import pytest_httpserver
 
 import rez_pip.pip

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 import os
+import re
 import platform
 import subprocess
 
@@ -40,7 +41,9 @@ def test_python_packages(setupRezPackages: str):
         )
 
         assert code == 0
-        assert stdout.decode("utf-8").strip().split(" ")[-1] == str(package.version)
+        assert re.findall(r"\d\.\d+\.\d+", stdout.decode("utf-8"), flags=re.MULTILINE)[
+            0
+        ] == str(package.version)
 
         code, stdout, _ = ctx.execute_shell(
             command=[executable, "-c", "import sys; print(sys.executable)"],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,29 @@
+import subprocess
+
+import rez.packages
+import rez.resolved_context
+import rez.vendor.version.version
+
+
+def test_python_packages(createPythonRezPackages, rezRepo: str):
+    """Test that the python rez packages created by createPythonRezPackages are functional"""
+    packages = list(rez.packages.iter_packages("python", paths=[rezRepo]))
+    assert sorted([str(package.version) for package in packages]) == [
+        "2.7.18",
+        "3.11.3",
+    ]
+
+    for package in packages:
+        ctx = rez.resolved_context.ResolvedContext(
+            [package.qualified_name], package_paths=[rezRepo]
+        )
+
+        code, stdout, _ = ctx.execute_shell(
+            command=[f"python{str(package.version).split('.')[0]}", "--version"],
+            block=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        assert code == 0
+        assert stdout.decode("utf-8").strip().split(" ")[-1] == str(package.version)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,13 +2,21 @@ import os
 import platform
 import subprocess
 
+import pytest
 import rez.packages
 import rez.resolved_context
 import rez.vendor.version.version
 
 
-def test_python_packages(createPythonRezPackages, rezRepo: str):
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and not os.environ.get("CI"),
+    reason="Skipping when running locally on macOS",
+)
+@pytest.mark.integration
+def test_python_packages(setupRezPackages: str):
     """Test that the python rez packages created by createPythonRezPackages are functional"""
+    rezRepo = setupRezPackages
+
     packages = list(rez.packages.iter_packages("python", paths=[rezRepo]))
     assert sorted([str(package.version) for package in packages]) == [
         "2.7.18",
@@ -33,7 +41,6 @@ def test_python_packages(createPythonRezPackages, rezRepo: str):
 
         assert code == 0
         assert stdout.decode("utf-8").strip().split(" ")[-1] == str(package.version)
-        print("Version:", stdout)
 
         code, stdout, _ = ctx.execute_shell(
             command=[executable, "-c", "import sys; print(sys.executable)"],


### PR DESCRIPTION
With this PR, we'll be able to add real integration tests.

The first integration test is simply resolving Python 2.7 and 3.11 and ensuring that they can be executed. The rez packages are created on the fly.