### PR TITLE
Use python rez packages

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -v --strict-markers --cov=rez_pip --cov-branch --cov-report=term-missing --cov-report=xml --showlocals
+addopts = -v --strict-markers --cov=rez_pip --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=html --showlocals
 
 norecursedirs = rez_repo
 

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -1,5 +1,4 @@
 import json
-import shlex
 import typing
 import logging
 import subprocess
@@ -59,7 +58,7 @@ def get_packages(
         "-",
     ]
 
-    _LOG.debug(f"Running {shlex.join(command)!r}")
+    _LOG.debug(f"Running {' '.join(command)!r}")
     output = subprocess.check_output(command)
 
     rawData = json.loads(output)

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -1,5 +1,5 @@
-import sys
 import json
+import shlex
 import typing
 import logging
 import subprocess
@@ -39,25 +39,28 @@ class PackageInfo(dataclasses_json.DataClassJsonMixin):
 
 
 def get_packages(
-    packageNames: typing.List[str], pip: str, pythonVersion: str
+    packageNames: typing.List[str], pip: str, pythonVersion: str, pythonExecutable: str
 ) -> typing.List[PackageInfo]:
     # python pip.pyz install -q requests --dry-run --ignore-installed --python-version 2.7 --only-binary=:all: --target /tmp/asd --report -
-    output = subprocess.check_output(
-        [
-            sys.executable,
-            pip,
-            "install",
-            "-q",
-            *packageNames,
-            "--dry-run",
-            "--ignore-installed",
-            f"--python-version={pythonVersion}" if pythonVersion else "",
-            "--only-binary=:all:",
-            "--target=/tmp/asd",
-            "--report",
-            "-",
-        ]
-    )
+
+    command = [
+        pythonExecutable,
+        pip,
+        "install",
+        "-q",
+        *packageNames,
+        "--dry-run",
+        "--ignore-installed",
+        f"--python-version={pythonVersion}" if pythonVersion else "",
+        "--only-binary=:all:",
+        "--target=/tmp/asd",
+        "--disable-pip-version-check",
+        "--report",
+        "-",
+    ]
+
+    _LOG.debug(f"Running {shlex.join(command)!r}")
+    output = subprocess.check_output(command)
 
     rawData = json.loads(output)
     rawPackages = rawData["install"]

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -133,7 +133,9 @@ def createPackage(
             pkg.authors = [author]
 
 
-def getPythonExecutables(range_: str, name: str = "python") -> typing.Dict[str, str]:
+def getPythonExecutables(
+    range_: typing.Optional[str], name: str = "python"
+) -> typing.Dict[str, str]:
     packages = sorted(
         rez.packages.iter_packages(name, range_=range_ if range_ != "latest" else None),
         key=lambda x: x.version,  # type: ignore
@@ -153,5 +155,9 @@ def getPythonExecutables(range_: str, name: str = "python") -> typing.Dict[str, 
             if path:
                 pythons[str(package.version)] = path
                 break
+        else:
+            _LOG.warning(
+                f"Failed to find a Python executable in the {package.qualified_name!r} rez package"
+            )
 
     return pythons

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -10,7 +10,9 @@ else:
     import importlib_metadata
 
 import rez.config
+import rez.packages
 import rez.package_maker
+import rez.resolved_context
 import rez.vendor.version.version
 
 import rez_pip.pip
@@ -24,6 +26,7 @@ def createPackage(
     isPure: bool,
     pythonVersion: rez.vendor.version.version.Version,
     nameCasings: typing.List[str],
+    tmpInstallPath: str,
     installPath: typing.Optional[str] = None,
 ) -> None:
     _LOG.info(f"Creating rez package for {dist.name}")
@@ -57,8 +60,9 @@ def createPackage(
         for src in dist.files:
             srcAbsolute = src.locate().resolve()
 
-            # TODO: Replace /tmp/asd with the path to the tmp dir
-            dest = os.path.join(path, srcAbsolute.relative_to("/tmp/asd"))
+            dest = os.path.join(
+                path, srcAbsolute.relative_to(os.path.realpath(tmpInstallPath))
+            )
             if not os.path.exists(os.path.dirname(dest)):
                 os.makedirs(os.path.dirname(dest))
 
@@ -127,3 +131,27 @@ def createPackage(
                 author += f" <{dist.metadata['Author-email']}>"
 
             pkg.authors = [author]
+
+
+def getPythonExecutables(range_: str, name: str = "python") -> typing.Dict[str, str]:
+    packages = sorted(
+        rez.packages.iter_packages(name, range_=range_ if range_ != "latest" else None),
+        key=lambda x: x.version,
+    )
+
+    if range_ == "latest":
+        packages = [packages[-1]]
+
+    pythons: typing.Dict[str, str] = {}
+    for package in packages:
+        resolvedContext = rez.resolved_context.ResolvedContext(
+            [f"{package.name}=={package.version}"]
+        )
+
+        for trimmedVersion in map(package.version.trim, [2, 1, 0]):
+            path = resolvedContext.which(f"python{trimmedVersion}")
+            if path:
+                pythons[str(package.version)] = path
+                break
+
+    return pythons

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -136,7 +136,7 @@ def createPackage(
 def getPythonExecutables(range_: str, name: str = "python") -> typing.Dict[str, str]:
     packages = sorted(
         rez.packages.iter_packages(name, range_=range_ if range_ != "latest" else None),
-        key=lambda x: x.version,
+        key=lambda x: x.version,  # type: ignore
     )
 
     if range_ == "latest":

--- a/tests/test_rez.py
+++ b/tests/test_rez.py
@@ -1,0 +1,114 @@
+import typing
+import unittest.mock
+
+import pytest
+import rez.config
+import rez.packages
+import rez.package_repository
+
+import rez_pip.rez
+
+
+@pytest.mark.parametrize(
+    "availableVersions,range_,executables,expectedExecutables",
+    [
+        pytest.param(
+            ["1.0.0"],
+            "latest",
+            ["python1.0"],
+            {"1.0.0": "/path/python1.0"},
+            id="latest",
+        ),
+        pytest.param(
+            ["1.0.0"],
+            None,
+            ["python1.0"],
+            {"1.0.0": "/path/python1.0"},
+            id="all-single-version",
+        ),
+        pytest.param(
+            ["1.0.0"],
+            None,
+            ["", "python1"],
+            {"1.0.0": "/path/python1"},
+            id="all-single-version-python1",
+        ),
+        pytest.param(
+            ["1.0.0"],
+            None,
+            ["", "", "python"],
+            {"1.0.0": "/path/python"},
+            id="all-single-version-python-no-version",
+        ),
+        pytest.param(
+            ["1.0.0"],
+            None,
+            ["", "", ""],
+            {},
+            id="all-single-version-no-exe",
+        ),
+        pytest.param(
+            ["1.0.0", "2.0.0"],
+            None,
+            ["python1.0", "python2.0"],
+            {"1.0.0": "/path/python1.0", "2.0.0": "/path/python2.0"},
+            id="all-multi-version",
+        ),
+        pytest.param(
+            ["1.0.0", "2.0.0"],
+            None,
+            ["", "", "", "python2.0"],
+            {"2.0.0": "/path/python2.0"},
+            id="all-multi-version-no-exe-1.0.0",
+        ),
+        pytest.param(
+            ["1.0.0", "2.0.0"],
+            "2+",
+            ["python2.0"],
+            {"2.0.0": "/path/python2.0"},
+            id="with-range-2plus",
+        ),
+        pytest.param(
+            ["1.0.0", "2.0.0"],
+            "<2",
+            ["python1.0"],
+            {"1.0.0": "/path/python1.0"},
+            id="with-range-less-than-2",
+        ),
+    ],
+)
+def test_getPythonExecutables(
+    monkeypatch: pytest.MonkeyPatch,
+    availableVersions: typing.List[str],
+    range_: typing.Optional[str],
+    executables: typing.List[str],
+    expectedExecutables: typing.Dict[str, str],
+) -> None:
+    repoData: typing.Dict[str, typing.Dict[str, typing.Dict[str, str]]] = {"python": {}}
+
+    for version in availableVersions:
+        repoData["python"][version] = {"version": version}
+
+    repo = typing.cast(
+        rez.package_repository.PackageRepository,
+        rez.package_repository.create_memory_package_repository(repoData),
+    )
+
+    with monkeypatch.context() as context:
+        context.setitem(
+            rez.package_repository.package_repository_manager.repositories,
+            f"memory@{repo.location}",
+            repo,
+        )
+
+        context.setattr(rez.config.config, "packages_path", [f"memory@{repo.location}"])
+
+        with unittest.mock.patch(
+            "rez.resolved_context.ResolvedContext.which"
+        ) as mocked:
+            mocked.side_effect = ["/path/" + exe if exe else "" for exe in executables]
+
+            assert (
+                rez_pip.rez.getPythonExecutables(range_, "python")
+                == expectedExecutables
+            )


### PR DESCRIPTION
Use python rez packages instead of using the rez install python executable.

This PR also enables installing packages for multiple python versions.