### PR TITLE
Re-organize integration tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ norecursedirs = rez_repo
 
 markers =
     integration: mark the tests as integration tests
+    py27: mark the tests has using a Python 2.7 rez package
+    py311: mark the tests has using a Python 3.11 rez package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,26 +21,26 @@ def rezRepo() -> str:
     return os.path.join(os.path.dirname(__file__), "data", "rez_repo")
 
 
-@pytest.fixture(scope="session")
-def downloadPythonVersions(
-    printer_session: typing.Callable[[str], None]
-) -> typing.List[typing.Tuple[str, str]]:
+def downloadPythonVersion(
+    version: str, printer_session: typing.Callable[[str], None]
+) -> str:
+    """
+    Download a Python interpreter for a given version
+
+    :param version: Python version to download.
+    :param printer_session: Pytest session printer.
+    :returns: Path to downloaded artifact.
+    """
     try:
         os.makedirs(DOWNLOAD_DIR)
     except FileExistsError:
         pass
 
-    urls: typing.Dict[str, str] = {}
-    versions = ["2.7.18", "3.11.3"]
+    url = ""
 
     if platform.system() == "Windows":
-        for version in versions:
-            nugetName = "python"
-            if version[0] == "2":
-                nugetName += "2"
-            urls[
-                version
-            ] = f"https://globalcdn.nuget.org/packages/{nugetName}.{version}.nupkg"
+        url = f"https://globalcdn.nuget.org/packages/python{'2' if version[0] == '2' else ''}.{version}.nupkg"
+
     elif platform.system() == "Darwin":
         # Use conda packages artifacts since they are portable and don't need to
         # be installed. That's quite dirty and I'm not sure if it goes against
@@ -53,7 +53,7 @@ def downloadPythonVersions(
 
         tree = xml.etree.ElementTree.fromstring(repodata)
 
-        versionFlter = "|".join([version.replace(".", "\\.") for version in versions])
+        versionFlter = version.replace(".", "\\.")
         regex = re.compile(rf"python-(?P<version>{versionFlter}).*\.tar\.bz2")
         for row in tree.iter("td"):
             name = next(row.itertext(), "")
@@ -62,13 +62,8 @@ def downloadPythonVersions(
 
             match = regex.match(name)
             if match:
-                urls[
-                    match.group("version")
-                ] = f"https://repo.anaconda.com/pkgs/main/osx-{arch}/{name}"
-            if len(urls) == len(versions):
+                url = f"https://repo.anaconda.com/pkgs/main/osx-{arch}/{name}"
                 break
-        if len(urls) != len(versions):
-            pytest.fail(f"Only found {len(urls)} versions in Anaconda repo: {urls}")
 
     else:
         with urllib.request.urlopen(
@@ -77,94 +72,106 @@ def downloadPythonVersions(
             versionsManifest = json.load(fd)
 
         for manifest in versionsManifest:
-            if manifest["version"] in versions:
-                for version in manifest["files"]:
+            if manifest["version"] == version:
+                for artifact in manifest["files"]:
                     if (
-                        version["arch"] == "x64"
-                        and version["platform"] == platform.system().lower()
+                        artifact["arch"] == "x64"
+                        and artifact["platform"] == platform.system().lower()
                     ):
-                        urls[manifest["version"]] = version["download_url"]
+                        url = artifact["download_url"]
                         break
                 else:
                     pytest.fail(f"Failed to find URL for Python {manifest['version']}")
+                break
 
-    items = []
-    for version, url in urls.items():
-        ext = re.findall(r"\.([a-z]\w+(?:\.?[a-z0-9]+))", url.split("/")[-1])[0]
-        filename = f"python-{version}-{platform.system().lower()}.{ext}"
+    if not url:
+        pytest.fail("URL to download Python {version} not found")
 
-        path = os.path.join(DOWNLOAD_DIR, filename)
+    ext = re.findall(r"\.([a-z]\w+(?:\.?[a-z0-9]+))", url.split("/")[-1])[0]
+    filename = f"python-{version}-{platform.system().lower()}.{ext}"
 
-        items.append([version, path])
+    path = os.path.join(DOWNLOAD_DIR, filename)
 
-        if os.path.exists(path):
-            printer_session(f"Skipping {url} because {path!r} already exists")
-            continue
+    if os.path.exists(path):
+        printer_session(f"Skipping {url} because {path!r} already exists")
+        return path
 
-        printer_session(f"Downloading {url} to {path!r}")
-        with urllib.request.urlopen(url) as archive:
-            with open(path, "wb") as targetFile:
-                targetFile.write(archive.read())
+    printer_session(f"Downloading {url} to {path!r}")
+    with urllib.request.urlopen(url) as archive:
+        with open(path, "wb") as targetFile:
+            targetFile.write(archive.read())
 
-    return items
+    return path
 
 
-@pytest.fixture(scope="session")
-def setupRezPackages(
-    downloadPythonVersions: typing.List[typing.Tuple[str, str]],
+@pytest.fixture(
+    scope="session",
+    params=[
+        pytest.param("2.7.18", marks=pytest.mark.py27),
+        pytest.param("3.11.3", marks=pytest.mark.py311),
+    ],
+)
+def pythonRezPackage(
+    request: pytest.FixtureRequest,
     rezRepo: str,
     printer_session: typing.Callable[[str], None],
 ) -> str:
-    for version, archivePath in downloadPythonVersions:
-        if not os.path.exists(archivePath):
-            pytest.fail(f"Cannot install {archivePath!r} because it does not exist")
+    """
+    Create a Python rez package and return Python version number.
+    """
+    version = typing.cast(str, request.param)
+    archivePath = downloadPythonVersion(version, printer_session)
 
-        if archivePath.endswith(".tar.gz"):
-            openArchive = tarfile.open
-        elif archivePath.endswith(".tar.bz2"):
-            openArchive = functools.partial(tarfile.open, mode="r:bz2")
-        elif archivePath.endswith(".nupkg"):
-            openArchive = zipfile.ZipFile
-        else:
-            raise RuntimeError(f"{archivePath} is of unknown type")
+    # for version, archivePath in downloadPythonVersions:
+    if not os.path.exists(archivePath):
+        pytest.fail(f"Cannot install {archivePath!r} because it does not exist")
 
-        def make_root(variant: rez.packages.Variant, path: str) -> None:
-            """Using distlib to iterate over all installed files of the current
-            distribution to copy files to the target directory of the rez package
-            variant
-            """
-            printer_session(f"Creating rez package for {archivePath} in {rezRepo!r}")
-            with openArchive(archivePath) as archive:
-                archive.extractall(path=os.path.join(path, "python"))
+    if archivePath.endswith(".tar.gz"):
+        openArchive = tarfile.open
+    elif archivePath.endswith(".tar.bz2"):
+        openArchive = functools.partial(tarfile.open, mode="r:bz2")
+    elif archivePath.endswith(".nupkg"):
+        openArchive = zipfile.ZipFile
+    else:
+        raise RuntimeError(f"{archivePath} is of unknown type")
 
-        with rez.package_maker.make_package(
-            "python",
-            rezRepo,
-            make_root=make_root,
-            skip_existing=True,
-            warn_on_skip=False,
-        ) as pkg:
-            pkg.version = version
+    def make_root(variant: rez.packages.Variant, path: str) -> None:
+        """Using distlib to iterate over all installed files of the current
+        distribution to copy files to the target directory of the rez package
+        variant
+        """
+        printer_session(f"Creating rez package for {archivePath} in {rezRepo!r}")
+        with openArchive(archivePath) as archive:
+            archive.extractall(path=os.path.join(path, "python"))
 
+    with rez.package_maker.make_package(
+        "python",
+        rezRepo,
+        make_root=make_root,
+        skip_existing=True,
+        warn_on_skip=False,
+    ) as pkg:
+        pkg.version = version
+
+        commands = [
+            "env.PATH.prepend('{root}/python/bin')",
+            "env.LD_LIBRARY_PATH.prepend('{root}/python/lib')",
+        ]
+        if platform.system() == "Windows":
+            commands = [
+                "env.PATH.prepend('{root}/python/tools')",
+                "env.PATH.prepend('{root}/python/tools/DLLs')",
+            ]
+        elif platform.system() == "Darwin":
             commands = [
                 "env.PATH.prepend('{root}/python/bin')",
-                "env.LD_LIBRARY_PATH.prepend('{root}/python/lib')",
             ]
-            if platform.system() == "Windows":
-                commands = [
-                    "env.PATH.prepend('{root}/python/tools')",
-                    "env.PATH.prepend('{root}/python/tools/DLLs')",
-                ]
-            elif platform.system() == "Darwin":
-                commands = [
-                    "env.PATH.prepend('{root}/python/bin')",
-                ]
 
-            pkg.commands = "\n".join(commands)
+        pkg.commands = "\n".join(commands)
 
-        if pkg.skipped_variants:
-            printer_session(
-                f"Python {version} rez package already exists at {pkg.skipped_variants[0].uri}"
-            )
+    if pkg.skipped_variants:
+        printer_session(
+            f"Python {version} rez package already exists at {pkg.skipped_variants[0].uri}"
+        )
 
-    return rezRepo
+    return version

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,52 +14,47 @@ import rez.vendor.version.version
     reason="Skipping when running locally on macOS",
 )
 @pytest.mark.integration
-def test_python_packages(setupRezPackages: str):
+def test_python_packages(pythonRezPackage: str, rezRepo: str):
     """Test that the python rez packages created by createPythonRezPackages are functional"""
-    rezRepo = setupRezPackages
 
-    packages = list(rez.packages.iter_packages("python", paths=[rezRepo]))
-    assert sorted([str(package.version) for package in packages]) == [
-        "2.7.18",
-        "3.11.3",
-    ]
+    package = rez.packages.get_package("python", pythonRezPackage, paths=[rezRepo])
+    assert package
 
-    for package in packages:
-        ctx = rez.resolved_context.ResolvedContext(
-            [package.qualified_name], package_paths=[rezRepo]
-        )
+    ctx = rez.resolved_context.ResolvedContext(
+        [package.qualified_name], package_paths=[rezRepo]
+    )
 
-        executable = f"python{str(package.version).split('.')[0]}"
-        if platform.system() == "Windows":
-            executable = "python.exe"
+    executable = f"python{str(package.version).split('.')[0]}"
+    if platform.system() == "Windows":
+        executable = "python.exe"
 
-        code, stdout, _ = ctx.execute_shell(
-            command=[executable, "--version"],
-            block=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+    code, stdout, _ = ctx.execute_shell(
+        command=[executable, "--version"],
+        block=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
 
-        assert code == 0
-        assert re.findall(r"\d\.\d+\.\d+", stdout.decode("utf-8"), flags=re.MULTILINE)[
-            0
-        ] == str(package.version)
+    assert code == 0
+    assert re.findall(r"\d\.\d+\.\d+", stdout.decode("utf-8"), flags=re.MULTILINE)[
+        0
+    ] == str(package.version)
 
-        code, stdout, _ = ctx.execute_shell(
-            command=[executable, "-c", "import sys; print(sys.executable)"],
-            block=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
+    code, stdout, _ = ctx.execute_shell(
+        command=[executable, "-c", "import sys; print(sys.executable)"],
+        block=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
 
-        expectedPath = os.path.join(
-            rezRepo,
-            "python",
-            str(package.version),
-            "python",
-            "tools" if platform.system() == "Windows" else "bin",
-            executable,
-        )
+    expectedPath = os.path.join(
+        rezRepo,
+        "python",
+        str(package.version),
+        "python",
+        "tools" if platform.system() == "Windows" else "bin",
+        executable,
+    )
 
-        assert code == 0
-        assert stdout.decode("utf-8").strip().lower() == expectedPath.lower()
+    assert code == 0
+    assert stdout.decode("utf-8").strip().lower() == expectedPath.lower()


### PR DESCRIPTION
Re-organize integration tests to be more modular and take advantage of markers for the different python versions.