### PR TITLE
Improved CLI and forward extra arguments to pip

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,10 @@ on:
     paths-ignore:
     - .github/workflows/update_pip.yaml
     - docs
-  pull_request:
-    paths-ignore:
-    - .github/workflows/update_pip.yaml
-    - docs
+  # pull_request:
+  #   paths-ignore:
+  #   - .github/workflows/update_pip.yaml
+  #   - docs
 
 concurrency:
   cancel-in-progress: true
@@ -19,6 +19,7 @@ jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11']

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project: off
+
+github_checks:
+  annotations: false

--- a/src/rez_pip/exceptions.py
+++ b/src/rez_pip/exceptions.py
@@ -1,0 +1,18 @@
+import rich
+import rich.console
+
+
+class RezPipError(Exception):
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __rich_console__(
+        self, console: rich.console.Console, options: rich.console.ConsoleOptions
+    ) -> rich.console.RenderResult:
+        yield console.render_str(
+            f"{self.__class__.__module__}.{self.__class__.__name__}: {self.message}"
+        )
+
+
+class PipError(RezPipError):
+    pass


### PR DESCRIPTION
Improvements to the CLI:
* Improved and consistent metavars "<...>".
* Add `-r/--requirement` to mimic pip.
* Add -c/--constraint to mimic pip.
* -d/--debug replace with -l/--log-level to be more flexible.
* Raise when the provided pip isn't a zippapp and doesn't exist.
* It is now possible to forward arguments to pip by using `--`: `rez-pip2 ... -- -vvvv --index-url ...`.
* Consequently, passing `-v` flags to pip will correctly log to stdout in real time.