### PR TITLE
Remove --target from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,10 @@ Modern rez-pip implementation. Very WIP.
 For now, it can be run like this:
 
 ```
-rm -rf /tmp/asd* && rez-pip2 pytest --target /tmp/asd --install-path /tmp/asd2
+rez-pip2 pytest
 ```
 
-`--target` is where the wheels will initially be installed and `--install-path` is
-where the rez packages will be created.
-
-`--target` is temporary and is simply a development flag.
+By default, rez packages will be released. You can choose a different path by passing the `--install-path` argument to rez-pip2.
 
 # Packages to test against
 

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -26,7 +26,7 @@ def createPackage(
     isPure: bool,
     pythonVersion: rez.vendor.version.version.Version,
     nameCasings: typing.List[str],
-    tmpInstallPath: str,
+    installedWheelsDir: str,
     installPath: typing.Optional[str] = None,
 ) -> None:
     _LOG.info(f"Creating rez package for {dist.name}")
@@ -34,6 +34,7 @@ def createPackage(
     version = rez_pip.utils.pythonDistributionVersionToRez(dist.version)
 
     requirements = rez_pip.utils.getRezRequirements(dist, pythonVersion, isPure, [])
+
     requires = requirements.requires
     variant_requires = requirements.variant_requires
     metadata = requirements.metadata
@@ -66,7 +67,7 @@ def createPackage(
             srcAbsolute = src.locate().resolve()
 
             dest = os.path.join(
-                path, srcAbsolute.relative_to(os.path.realpath(tmpInstallPath))
+                path, srcAbsolute.relative_to(os.path.realpath(installedWheelsDir))
             )
             if not os.path.exists(os.path.dirname(dest)):
                 os.makedirs(os.path.dirname(dest))


### PR DESCRIPTION
Remove `--target` from CLI and use temporary directory to store wheels and their artifacts.

This was long overdue.