### PR TITLE
Add tests for console scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Modern rez-pip implementation. Very WIP.
 * [ ] Better logs and CLI experience
     * [x] Use logging
     * [x] Progress bars for download?
-* [ ] Confirm that Python 2 is supported
-* [ ] Confirm that the theory works as expected
-* [ ] Windows support
+* [x] Confirm that Python 2 is supported
+* [x] Confirm that the theory works as expected
+* [x] Windows support
 * [ ] Hook into rez
     * [x] Install each package in a different `--target`
     * [x] Create rez package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,6 +144,17 @@ def pythonRezPackage(
         with openArchive(archivePath) as archive:
             archive.extractall(path=os.path.join(path, "python"))
 
+        versionLessExec = os.path.join(path, "python", "bin", f"python")
+        if not os.path.exists(versionLessExec):
+            if (
+                int(variant.version.as_tuple()[0]) >= 3
+                and platform.system() != "Windows"
+            ):
+                os.symlink(
+                    f"{versionLessExec}{variant.version.major}",
+                    versionLessExec,
+                )
+
     with rez.package_maker.make_package(
         "python",
         rezRepo,

--- a/tests/data/src_packages/console_scripts/pyproject.toml
+++ b/tests/data/src_packages/console_scripts/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "console_scripts"
+version = "0.1.0"
+
+[project.scripts]
+console_scripts_cmd = "console_scripts:run"

--- a/tests/data/src_packages/console_scripts/src/console_scripts/__init__.py
+++ b/tests/data/src_packages/console_scripts/src/console_scripts/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+
+def run():
+    # We want to test that the executable is really the correct one, the one we expect.
+    # So printing it will allow us to compare it.
+    sys.stdout.write(sys.executable)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ pytest-cov>=4.0.0
 pytest-print
 # Needed because of the use of async mocks which were fully added in 3.8
 mock; python_version < "3.8"
+build

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,17 @@
+import os
+import sys
+import glob
+import pathlib
+import platform
+import subprocess
+
+import pytest
 import installer.utils
+
+import rez_pip.pip
+import rez_pip.install
+
+from . import utils
 
 
 def test_installer_schemes():
@@ -11,3 +24,63 @@ def test_installer_schemes():
         "scripts",
         "data",
     )
+
+
+# @pytest.fixture(scope="module")
+def buildPackage(name: str, outputDir: str):
+    sourcePath = os.path.join(os.path.dirname(__file__), "data", "src_packages", name)
+
+    subprocess.run(
+        [sys.executable, "-m", "build", "-w", ".", "--outdir", outputDir],
+        cwd=sourcePath,
+        check=True,
+    )
+
+    return glob.glob(os.path.join(outputDir, "*.whl"))[0]
+
+
+@pytest.mark.integration
+def test_console_scripts(pythonRezPackage: str, rezRepo: str, tmp_path: pathlib.Path):
+    executable, ctx = utils.getPythonRezPackageExecutablePath(pythonRezPackage, rezRepo)
+
+    wheel = buildPackage("console_scripts", str(tmp_path / "wheels"))
+
+    installPath = tmp_path / "install"
+    rez_pip.install.installWheel(
+        rez_pip.pip.PackageInfo(
+            rez_pip.pip.DownloadInfo(
+                f"url",
+                rez_pip.pip.ArchiveInfo(
+                    "sha256=af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
+                    {
+                        "sha256": "af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171"
+                    },
+                ),
+            ),
+            False,
+            True,
+            rez_pip.pip.Metadata("0.1.0", "console_scripts"),
+        ),
+        wheel,
+        os.fspath(installPath),
+    )
+
+    consoleScript = os.fspath(installPath / "scripts" / "console_scripts_cmd")
+    if platform.system() == "Windows":
+        consoleScript += ".exe"
+
+    assert os.path.exists(consoleScript), f"{consoleScript!r} does not exists!"
+
+    code, stdout, _ = ctx.execute_shell(
+        command=[consoleScript],
+        block=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        parent_environ={"PYTHONPATH": os.fspath(installPath / "python")},
+        text=True,
+    )
+
+    # Use dirnames to avoid having to deal woth python vs python2 or python vs python3
+    assert os.path.dirname(stdout) == os.path.dirname(
+        executable
+    ), f"stdout is {stdout!r} and executable is {executable!r}"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ import rez.vendor.version.version
 )
 @pytest.mark.integration
 def test_python_packages(pythonRezPackage: str, rezRepo: str):
-    """Test that the python rez packages created by createPythonRezPackages are functional"""
+    """Test that the python rez packages created by the pythonRezPackage fixture are functional"""
 
     package = rez.packages.get_package("python", pythonRezPackage, paths=[rezRepo])
     assert package

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,20 @@
+import platform
+
+import rez.packages
+import rez.resolved_context
+import rez.vendor.version.version
+
+
+def getPythonRezPackageExecutablePath(version: str, repo: str):
+    package = rez.packages.get_package("python", version, paths=[repo])
+    assert package
+
+    ctx = rez.resolved_context.ResolvedContext(
+        [package.qualified_name], package_paths=[repo]
+    )
+
+    executable = f"python{str(package.version).split('.')[0]}"
+    if platform.system() == "Windows":
+        executable = "python.exe"
+
+    return ctx.which(executable), ctx


### PR DESCRIPTION
Add tests for console scripts. These confirms the theory that I can use the `install` library with Python 3 to install a Python 2 package and have the console script to work.

It also confirms that the custom shebang works on Windows without having to install a package for both Python 2 and 3.