### PR TITLE
Add tests for rez_pip and drop support for installing Python 2 packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -s
+      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
 
     - name: Codecov upload
       uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
-# C extensions
-*.so
-
 # Distribution / packaging
-.Python
-build/
-develop-eggs/
 dist/
 downloads/
 eggs/
@@ -27,79 +21,17 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
-.tox/
 .nox/
 .coverage
 .coverage.*
 .cache
-nosetests.xml
 coverage.xml
 *.cover
 *.py,cover
 .hypothesis/
 .pytest_cache/
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-.python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -110,16 +42,6 @@ ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
 # mypy
 .mypy_cache/
 .dmypy.json
@@ -128,10 +50,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Custom
-.nox
+# Other
 .vscode
-tests/data/rez_repo
-tests/data/_tmp_download
-docs/build
-docs/bin
+/docs/build/
+tests/data/rez_repo/
+tests/data/_tmp_download/
+docs/bin/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Modern rez-pip implementation. Very WIP.
     * [x] Use logging
     * [x] Progress bars for download?
 * [x] Confirm that Python 2 is supported
+    * It is not...
 * [x] Confirm that the theory works as expected
 * [x] Windows support
 * [ ] Hook into rez

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ Features
 ========
 
 * Simpler to use thanks to the vendoring of pip.
-* Supports installing Python 2 and 3 packages.
+* Does **not** support installing packages for Python 2.
 * Better output logs.
 * Implemented as an out-of-tree plugin, which means faster development cycle and more frequent releases.
 * Maintained by the rez maintainers.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,18 @@
 [pytest]
-addopts = -v --strict-markers --cov=rez_pip --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=html
+addopts =
+    -v
+    --strict-markers
+    --cov=rez_pip
+    --cov-branch
+    --cov-report=term-missing
+    --cov-report=xml
+    --cov-report=html
+    --durations=0
 
 norecursedirs = rez_repo
 
 markers =
     integration: mark the tests as integration tests
-    py27: mark the tests has using a Python 2.7 rez package
+    py37: mark the tests has using a Python 3.7 rez package
+    py39: mark the tests has using a Python 3.7 rez package
     py311: mark the tests has using a Python 3.11 rez package

--- a/tests/data/src_packages/package_a/pyproject.toml
+++ b/tests/data/src_packages/package_a/pyproject.toml
@@ -1,0 +1,11 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "package_a"
+version = "1.0.0"
+
+dependencies = [
+    "package_b"
+]

--- a/tests/data/src_packages/package_a/src/console_scripts/__init__.py
+++ b/tests/data/src_packages/package_a/src/console_scripts/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+
+def run():
+    # We want to test that the executable is really the correct one, the one we expect.
+    # So printing it will allow us to compare it.
+    sys.stdout.write(sys.executable)

--- a/tests/data/src_packages/package_b/pyproject.toml
+++ b/tests/data/src_packages/package_b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "package_b"
+version = "2.0.0"

--- a/tests/data/src_packages/package_b/src/console_scripts/__init__.py
+++ b/tests/data/src_packages/package_b/src/console_scripts/__init__.py
@@ -1,0 +1,7 @@
+import sys
+
+
+def run():
+    # We want to test that the executable is really the correct one, the one we expect.
+    # So printing it will allow us to compare it.
+    sys.stdout.write(sys.executable)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,11 @@
-pytest>=7.2.0
-pytest-cov>=4.0.0
+pytest
+pytest-cov
 pytest-print
+pypiserver
 # Needed because of the use of async mocks which were fully added in 3.8
 mock; python_version < "3.8"
 build
+hatchling
+git+https://github.com/conda/conda-package-handling@2.1.0; platform_system != "Windows"
+# 23.1.0 is the last version to support Python 3.7
+git+https://github.com/conda/conda@23.1.0; platform_system != "Windows"

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -1,0 +1,193 @@
+import os
+import re
+import sys
+import uuid
+import typing
+import pathlib
+import subprocess
+
+import rich
+import pytest
+
+import rez_pip.pip
+import rez_pip.exceptions
+
+from . import utils
+
+
+def test_getBundledPip():
+    """Test that the bundled pip exists and can be executed"""
+    assert os.path.exists(rez_pip.pip.getBundledPip())
+
+    subprocess.run([sys.executable, rez_pip.pip.getBundledPip(), "-h"])
+
+
+@pytest.mark.parametrize(
+    "packages,expectedPackages",
+    [
+        [
+            ["package_a"],
+            [
+                rez_pip.pip.PackageInfo(
+                    rez_pip.pip.DownloadInfo(
+                        "{pypi}/packages/package_a/package_a-1.0.0-py2.py3-none-any.whl",
+                        rez_pip.pip.ArchiveInfo(
+                            "sha256=<val>",
+                            {"sha256": "<val>"},
+                        ),
+                    ),
+                    False,
+                    True,
+                    rez_pip.pip.Metadata("1.0.0", "package_a"),
+                ),
+            ],
+        ],
+        [
+            ["package_a", "console_scripts"],
+            [
+                rez_pip.pip.PackageInfo(
+                    rez_pip.pip.DownloadInfo(
+                        "{pypi}/packages/package_a/package_a-1.0.0-py2.py3-none-any.whl",
+                        rez_pip.pip.ArchiveInfo(
+                            "sha256=<val>",
+                            {"sha256": "<val>"},
+                        ),
+                    ),
+                    False,
+                    True,
+                    rez_pip.pip.Metadata("1.0.0", "package_a"),
+                ),
+                rez_pip.pip.PackageInfo(
+                    download_info=rez_pip.pip.DownloadInfo(
+                        url="{pypi}/packages/console_scripts/console_scripts-0.1.0-py2.py3-none-any.whl",
+                        archive_info=rez_pip.pip.ArchiveInfo(
+                            hash="sha256=<val>",
+                            hashes={"sha256": "<val>"},
+                        ),
+                    ),
+                    is_direct=False,
+                    requested=True,
+                    metadata=rez_pip.pip.Metadata(
+                        version="0.1.0", name="console_scripts"
+                    ),
+                ),
+            ],
+        ],
+    ],
+    ids=["package_a", "package_a+console_scripts"],
+)
+def test_getPackages_no_deps(
+    packages: typing.List[str],
+    expectedPackages: typing.List[rez_pip.pip.PackageInfo],
+    pythonRezPackage: str,
+    rezRepo: str,
+    pypi: str,
+    index: utils.PyPIIndex,
+):
+    """
+    This just tests that the function returns PackageInfo objects
+    and it's why we use --no-deps. The scenario with dependencies
+    will be tested in another test.
+    """
+    executable, ctx = utils.getPythonRezPackageExecutablePath(pythonRezPackage, rezRepo)
+    assert executable is not None
+
+    for expectedPackage in expectedPackages:
+        expectedPackage.download_info.archive_info.hash = (
+            f"sha256={index.getWheelHash(expectedPackage.name)}"
+        )
+        expectedPackage.download_info.archive_info.hashes = {
+            "sha256": index.getWheelHash(expectedPackage.name)
+        }
+
+    resolvedPackages = rez_pip.pip.getPackages(
+        packages,
+        rez_pip.pip.getBundledPip(),
+        "3.11",
+        executable,
+        [],
+        [],
+        ["--index-url", pypi, "-vvv", "--no-deps", "--retries=0"],
+    )
+
+    for packageInfo in expectedPackages:
+        packageInfo.download_info.url = packageInfo.download_info.url.format(pypi=pypi)
+
+    assert resolvedPackages == expectedPackages
+
+
+def test_getPackages_with_deps(
+    pythonRezPackage: str,
+    rezRepo: str,
+    pypi: str,
+):
+    """
+    Test that we get all dependencies
+    """
+    executable, ctx = utils.getPythonRezPackageExecutablePath(pythonRezPackage, rezRepo)
+    assert executable is not None
+
+    resolvedPackages = rez_pip.pip.getPackages(
+        ["package_a"],
+        rez_pip.pip.getBundledPip(),
+        "3.11",
+        executable,
+        [],
+        [],
+        ["--index-url", pypi, "-vvv", "--retries=0"],
+    )
+
+    resolvedPackageNames = [pkg.name for pkg in resolvedPackages]
+
+    assert sorted(resolvedPackageNames) == ["package_a", "package_b"]
+
+
+def test_getPackages_error(
+    pythonRezPackage: str, rezRepo: str, pypi: str, tmp_path: pathlib.Path
+):
+    executable, ctx = utils.getPythonRezPackageExecutablePath(pythonRezPackage, rezRepo)
+    assert executable is not None
+
+    packageName = str(uuid.uuid4())
+
+    with pytest.raises(rez_pip.exceptions.PipError) as exc:
+        rez_pip.pip.getPackages(
+            [packageName],
+            rez_pip.pip.getBundledPip(),
+            ".".join(str(i) for i in sys.version_info[:2]),
+            executable,
+            [],
+            [],
+            # Disable retries to speed up the test
+            [
+                # Specify index to avoid pip complaining about OpenSSL not being available.
+                f"--index-url={pypi}",
+                "--find-links",
+                os.fspath(tmp_path),
+                "-v",
+                "--retries",
+                "0",
+            ],
+        )
+
+    with rich.get_console().capture() as capture:
+        rich.get_console().print(exc.value, soft_wrap=True)
+
+    match = re.match(
+        r"rez_pip\.exceptions\.PipError: Failed to run pip command\: '.*'",
+        capture.get().splitlines()[0],
+    )
+
+    assert match is not None
+
+    # Lowercase to avoid discrepencies between C:\ and c:\
+    assert (
+        "\n".join(capture.get().splitlines()[1:]).lower()
+        == f"""
+Pip reported this:
+
+Looking in indexes: {pypi}
+Looking in links: {os.fspath(tmp_path)}
+ERROR: Could not find a version that satisfies the requirement {packageName} (from versions: none)
+ERROR: No matching distribution found for {packageName}""".lower()
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,11 @@
+import os
+import sys
+import glob
+import hashlib
+import pathlib
 import platform
+import subprocess
+import collections
 
 import rez.packages
 import rez.resolved_context
@@ -18,3 +25,59 @@ def getPythonRezPackageExecutablePath(version: str, repo: str):
         executable = "python.exe"
 
     return ctx.which(executable), ctx
+
+
+def buildPackage(name: str, outputDir: str) -> pathlib.Path:
+    sourcePath = os.path.join(os.path.dirname(__file__), "data", "src_packages", name)
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "-w",
+            ".",
+            "--outdir",
+            outputDir,
+            "--no-isolation",
+        ],
+        cwd=sourcePath,
+        check=True,
+    )
+
+    return pathlib.Path(glob.glob(os.path.join(outputDir, f"{name}*.whl"))[0])
+
+
+class PyPIIndex:
+    def __init__(self, path: pathlib.Path):
+        self._path = path
+        self._cache = collections.defaultdict(dict)
+
+    @property
+    def path(self) -> pathlib.Path:
+        return self._path
+
+    def getWheel(self, name: str) -> pathlib.Path:
+        return next(self.path.joinpath(name).glob("*.whl"))
+
+    def getWheelHash(self, name: str, typ="sha256") -> str:
+        path = self.getWheel(name)
+
+        cachedValue = self._cache[typ].get(path)
+        if cachedValue:
+            return cachedValue
+
+        buf = bytearray(2**18)  # Reusable buffer to reduce allocations.
+        view = memoryview(buf)
+
+        digestobj = hashlib.new(typ)
+        with open(path, "rb") as fd:
+            while True:
+                size = fd.readinto(buf)
+                if size == 0:
+                    break  # EOF
+                digestobj.update(view[:size])
+
+        digest = digestobj.hexdigest()
+        self._cache[typ][path] = digest
+        return digest


### PR DESCRIPTION
Add tests for rez_pip and drop support for installing Python 2 packages.

We had to drop support for installing Python 2 packages because when running pip with `--python-version` and all the other flags (`--platform`, etc), pip doesn't evaluate the markers on the dependencies based on the information provided. It uses the current interpreter's values... In other words, if we run `<sys.executable> pip.pyz install <package> --python-version 2.7` where `sys.executable` is a Python 3 executable, we will get the dependencies for Python 3 and not 2! See https://github.com/pypa/pip/issues/11664 for more details.

We could potentially hack a solution together, for example by creating a `sitecustomize` or `usercustomize` file, or maybe even a `.pth` file that would override the `sys` and `os` values used by markers... But that would be quite fragile.

Lastly, the version of pip we need isn't compatible with Python 2.

This means that dropping support for installing Python 2 packages is our only option right now.