### PR TITLE
Replace usage of rez.vendor.version with rez.version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ dependencies = [
     "installer>=0.7.0",
     "aiohttp",
     "packaging>=23.1",
-    "rez",
+    # 2.114.0 adds rez.version.
+    "rez>=2.114.1",
     "dataclasses-json",
     "rich",
     "importlib_metadata>=4.6 ; python_version < '3.10'",

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -18,9 +18,9 @@ else:
 import rich
 import rich.text
 import rich.panel
+import rez.version
 import rich.markup
 import rich.logging
-import rez.vendor.version.version
 
 import rez_pip.pip
 import rez_pip.rez
@@ -217,7 +217,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
                 rez_pip.rez.createPackage(
                     dist,
                     isPure,
-                    rez.vendor.version.version.Version(pythonVersion),
+                    rez.version.Version(pythonVersion),
                     distNames,
                     installedWheelsDir,
                     wheelURL=package.download_info.url,

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -13,10 +13,10 @@ else:
     import importlib_metadata
 
 import rez.config
+import rez.version
 import rez.packages
 import rez.package_maker
 import rez.resolved_context
-import rez.vendor.version.version
 
 import rez_pip.pip
 import rez_pip.utils
@@ -27,7 +27,7 @@ _LOG = logging.getLogger(__name__)
 def createPackage(
     dist: importlib_metadata.Distribution,
     isPure: bool,
-    pythonVersion: rez.vendor.version.version.Version,
+    pythonVersion: rez.version.Version,
     nameCasings: typing.List[str],
     installedWheelsDir: str,
     wheelURL: str,

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -9,11 +9,10 @@ else:
     import importlib_metadata
 
 import rez.system
+import rez.version
 import packaging.version
 import packaging.specifiers
 import packaging.requirements
-import rez.vendor.version.version
-import rez.vendor.version.requirement
 
 _LOG = logging.getLogger(__name__)
 
@@ -115,7 +114,7 @@ def pythonDistributionVersionToRez(version: str) -> str:
 
 def pythonSpecifierToRezRequirement(
     specifier: packaging.specifiers.SpecifierSet,
-) -> rez.vendor.version.version.VersionRange:
+) -> rez.version.VersionRange:
     """Convert PEP440 version specifier to rez equivalent.
 
     See https://www.python.org/dev/peps/pep-0440/#version-specifiers
@@ -220,7 +219,7 @@ def pythonSpecifierToRezRequirement(
 
         # ~=1.2 --> 1.2+<2; ~=1.2.3 --> 1.2.3+<1.3
         if spec.operator == "~=":
-            v = rez.vendor.version.version.Version(parsed_rez_ver())
+            v = rez.version.Version(parsed_rez_ver())
             v = v.trim(len(v) - 1)
             v_next = next_ver(str(v))
             return fmt("{V}+<" + v_next)
@@ -242,10 +241,10 @@ def pythonSpecifierToRezRequirement(
     ranges = list(map(convert_spec, specifier))
 
     # AND together ranges
-    total_range = rez.vendor.version.version.VersionRange(ranges[0])
+    total_range = rez.version.VersionRange(ranges[0])
 
     for range_ in ranges[1:]:
-        range_ = rez.vendor.version.version.VersionRange(range_)
+        range_ = rez.version.VersionRange(range_)
         total_range = total_range.intersection(range_)
 
         if total_range is None:
@@ -259,7 +258,7 @@ def pythonSpecifierToRezRequirement(
 
 def pythonReqToRezReq(
     pythonReq: packaging.requirements.Requirement,
-) -> rez.vendor.version.requirement.Requirement:
+) -> rez.version.Requirement:
     """Convert packaging requirement object to equivalent rez requirement.
 
     Note that environment markers are ignored.
@@ -278,7 +277,7 @@ def pythonReqToRezReq(
         range_ = pythonSpecifierToRezRequirement(pythonReq.specifier)
         req += "-" + str(range_)
 
-    return rez.vendor.version.requirement.Requirement(req)
+    return rez.version.Requirement(req)
 
 
 class CustomPyPackagingRequirement(packaging.requirements.Requirement):
@@ -466,7 +465,7 @@ def convertMarker(marker: str) -> typing.List[str]:
 
 def getRezRequirements(
     installedDist: importlib_metadata.Distribution,
-    pythonVersion: rez.vendor.version.version.Version,
+    pythonVersion: rez.version.Version,
     isPure: bool,
     nameCasings: typing.Optional[typing.List[str]] = None,
 ) -> RequirementsDict:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,9 +4,9 @@ import platform
 import subprocess
 
 import pytest
+import rez.version
 import rez.packages
 import rez.resolved_context
-import rez.vendor.version.version
 
 
 @pytest.mark.skipif(

--- a/tests/test_rez.py
+++ b/tests/test_rez.py
@@ -8,9 +8,9 @@ import unittest.mock
 
 import pytest
 import rez.config
+import rez.version
 import rez.packages
 import rez.package_repository
-import rez.vendor.version.version
 
 if sys.version_info >= (3, 10):
     import importlib.metadata as importlib_metadata
@@ -68,7 +68,7 @@ def test_createPackage(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
         rez_pip.rez.createPackage(
             dist,
             False,
-            rez.vendor.version.version.Version("3.7.0"),
+            rez.version.Version("3.7.0"),
             [],
             source,
             "http://localhost/asd",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,10 @@
 import typing
 
 import pytest
+import rez.version
 import packaging.version
 import packaging.specifiers
 import packaging.requirements
-import rez.vendor.version.version
-import rez.vendor.version.requirement
 
 import rez_pip.utils
 
@@ -66,7 +65,7 @@ def test_pythonSpecifierToRezRequirement(pythonSpec: str, rezReq: str):
     pythonSpecObj = packaging.specifiers.SpecifierSet(pythonSpec)
     assert rez_pip.utils.pythonSpecifierToRezRequirement(
         pythonSpecObj
-    ) == rez.vendor.version.version.VersionRange(rezReq)
+    ) == rez.version.VersionRange(rezReq)
 
 
 def test_pythonSpecifierToRezRequirement_raises():
@@ -87,7 +86,7 @@ def test_pythonSpecifierToRezRequirement_raises():
 def test_packaging_req_to_rez_req(pythonReq: str, rezReq: str):
     assert rez_pip.utils.pythonReqToRezReq(
         packaging.requirements.Requirement(pythonReq)
-    ) == rez.vendor.version.requirement.Requirement(rezReq)
+    ) == rez.version.Requirement(rezReq)
 
 
 # def test_is_pure_python_package(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,9 +7,9 @@ import platform
 import subprocess
 import collections
 
+import rez.version
 import rez.packages
 import rez.resolved_context
-import rez.vendor.version.version
 
 
 def getPythonRezPackageExecutablePath(version: str, repo: str):


### PR DESCRIPTION
Replace usage of rez.vendor.version with rez.version introduced in rez 2.114.0.