### PR TITLE
Improve usability of rez_pip as python library.

### DIFF
--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -255,7 +255,7 @@ def run() -> int:
             return 0
 
         rez_pip.main.run_full_installation(
-            pipPackages=args.packages,
+            pipPackageNames=args.packages,
             pythonVersionRange=args.python_version,
             pipPath=args.pip,
             requirementPath=args.requirement,

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 import sys
 import json
 import shutil
@@ -234,7 +235,7 @@ def _debug(
 
 
 def run() -> int:
-    pipWorkArea = tempfile.mkdtemp(prefix="rez-pip-target")
+    pipWorkArea = pathlib.Path(tempfile.mkdtemp(prefix="rez-pip-target"))
     args, pipArgs = _parseArgs(sys.argv[1:])
 
     try:

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -254,7 +254,7 @@ def run() -> int:
             _debug(args)
             return 0
 
-        rez_pip.main.rez_install_pip_packages(
+        rez_pip.main.run_full_installation(
             pipPackages=args.packages,
             pythonVersionRange=args.python_version,
             pipPath=args.pip,

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -1,0 +1,124 @@
+import os
+import sys
+import typing
+import logging
+import pathlib
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+import rich
+import rez.version
+import rich.markup
+
+import rez_pip.pip
+import rez_pip.rez
+import rez_pip.install
+import rez_pip.download
+import rez_pip.exceptions
+
+_LOG = logging.getLogger(__name__)
+
+
+def rez_install_pip_packages(
+    pipPackages: list[str],
+    pythonVersionRange: typing.Optional[str],
+    pipPath: str,
+    requirementPath: typing.Optional[list[str]],
+    constraintPath: typing.Optional[list[str]],
+    rezInstallPath: typing.Optional[str],
+    rezRelease: bool,
+    pipArgs: typing.Optional[typing.List[str]],
+    pipWorkArea: str,
+) -> None:
+    """
+    Convert the given pip packages to rez packages compatibe with the given python versions.
+
+    :param pipPackages: list of packages name to install, in the syntax understood by pip.
+    :param pythonVersionRange: a single or range of python versions in the rez syntax
+    :param pipPath: filesystem path to the pip executable. If not provided use the bundled pip.
+    :param requirementPath: optional filesystem path to an existing python requirement file.
+    :param constraintPath: optional filesystem path to an existing python constraint file.
+    :param rezInstallPath:
+        optional filesystem path to an existing directory where to install the packages.
+        Default is the "local_packages_path".
+    :param rezRelease: True to release the package to the "release_packages_path"
+    :param pipArgs: additional argument passed directly to pip
+    :param pipWorkArea:
+        filesystem path to an existing directory that can be used for pip to install packages.
+    :return: None.
+    """
+    pythonVersions = rez_pip.rez.getPythonExecutables(
+        pythonVersionRange, packageFamily="python"
+    )
+
+    if not pythonVersions:
+        raise rez_pip.exceptions.RezPipError(
+            f'No "python" package found within the range {pythonVersionRange!r}.'
+        )
+
+    for pythonVersion, pythonExecutable in pythonVersions.items():
+        _LOG.info(
+            f"[bold underline]Installing requested packages for Python {pythonVersion}"
+        )
+
+        wheelsDir = os.path.join(pipWorkArea, "wheels")
+        os.makedirs(wheelsDir, exist_ok=True)
+
+        # Suffix with the python version because we loop over multiple versions,
+        # and package versions, content, etc can differ for each Python version.
+        installedWheelsDir = os.path.join(pipWorkArea, "installed", pythonVersion)
+        os.makedirs(installedWheelsDir, exist_ok=True)
+
+        with rich.get_console().status(
+            f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(pipPackages))} (python-{pythonVersion})"
+        ):
+            pipPackages = rez_pip.pip.getPackages(
+                pipPackages,
+                pipPath,
+                pythonVersion,
+                os.fspath(pythonExecutable),
+                requirementPath or [],
+                constraintPath or [],
+                pipArgs,
+            )
+
+        _LOG.info(
+            f"Resolved {len(pipPackages)} dependencies for python {pythonVersion}"
+        )
+
+        # TODO: Should we postpone downloading to the last minute if we can?
+        _LOG.info("[bold]Downloading...")
+        wheels = rez_pip.download.downloadPackages(pipPackages, wheelsDir)
+        _LOG.info(f"[bold]Downloaded {len(wheels)} wheels")
+
+        dists: typing.Dict[importlib_metadata.Distribution, bool] = {}
+
+        with rich.get_console().status(
+            f"[bold]Installing wheels into {installedWheelsDir!r}"
+        ):
+            for package, wheel in zip(pipPackages, wheels):
+                _LOG.info(f"[bold]Installing {package.name}-{package.version} wheel")
+                dist, isPure = rez_pip.install.installWheel(
+                    package, pathlib.Path(wheel), installedWheelsDir
+                )
+
+                dists[dist] = isPure
+
+        distNames = [dist.name for dist in dists.keys()]
+
+        with rich.get_console().status("[bold]Creating rez packages..."):
+            for dist, package in zip(dists, pipPackages):
+                isPure = dists[dist]
+                rez_pip.rez.createPackage(
+                    dist,
+                    isPure,
+                    rez.version.Version(pythonVersion),
+                    distNames,
+                    installedWheelsDir,
+                    wheelURL=package.download_info.url,
+                    prefix=rezInstallPath,
+                    release=rezRelease,
+                )

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -33,6 +33,17 @@ def run_full_installation(
     constraintPath: typing.Optional[typing.List[str]] = None,
     rezInstallPath: typing.Optional[str] = None,
     rezRelease: bool = False,
+    rezPackageCreationCallback: typing.Optional[
+        typing.Callable[
+            [
+                rez.package_maker.PackageMaker,
+                importlib_metadata.Distribution,
+                rez.version.Version,
+                bool,
+            ],
+            None,
+        ]
+    ] = None,
 ) -> typing.Dict[str, typing.List[rez.package_maker.PackageMaker]]:
     """
     Convert and install the given pip packages to rez packages compatible with the given python versions.
@@ -49,6 +60,10 @@ def run_full_installation(
     :param pipArgs: additional argument passed directly to pip
     :param pipWorkArea:
         filesystem path to an existing directory that can be used for pip to install packages.
+    :param rezPackageCreationCallback:
+        a function that is called for each rez package created, signature is as follows:
+        ``callable("package being created", "pip distribution", "python version", "being released")``.
+        It is being called after the package has been configured by rez_pip.
     :return:
         dict of rez packages created per python version: ``{"pythonVersion": PackageMaker()}``
         Note the PackageMaker object are already "close" and written to disk.
@@ -126,6 +141,7 @@ def run_full_installation(
                     wheelURL=package.download_info.url,
                     prefix=rezInstallPath,
                     release=rezRelease,
+                    creationCallback=rezPackageCreationCallback,
                 )
                 rezPackages.setdefault(pythonVersion, []).append(rezPackage)
 

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -35,10 +35,10 @@ def run_full_installation(
     rezRelease: bool = False,
 ) -> typing.Dict[str, typing.List[rez.package_maker.PackageMaker]]:
     """
-    Convert the given pip packages to rez packages compatibe with the given python versions.
+    Convert and install the given pip packages to rez packages compatible with the given python versions.
 
     :param pipPackageNames: list of packages to install, in the syntax understood by pip.
-    :param pythonVersionRange: a single or range of python versions in the rez syntax
+    :param pythonVersionRange: a single or range of python versions in the rez syntax.
     :param pipPath: filesystem path to the pip executable. If not provided use the bundled pip.
     :param requirementPath: optional filesystem path to an existing python requirement file.
     :param constraintPath: optional filesystem path to an existing python constraint file.

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -88,7 +88,7 @@ def pip_install_packages(
     return dists
 
 
-def rez_install_pip_packages(
+def run_full_installation(
     pipPackages: typing.List[str],
     pythonVersionRange: typing.Optional[str],
     pipPath: pathlib.Path,

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -40,7 +40,6 @@ def run_installation_for_python(
                 rez.package_maker.PackageMaker,
                 importlib_metadata.Distribution,
                 rez.version.Version,
-                bool,
             ],
             None,
         ]
@@ -64,7 +63,7 @@ def run_installation_for_python(
         filesystem path to an existing directory that can be used for pip to install packages.
     :param rezPackageCreationCallback:
         a function that is called for each rez package created, signature is as follows:
-        ``callable("package being created", "pip distribution", "python version", "being released")``.
+        ``callable("package being created", "pip distribution", "python version")``.
         It is being called after the package has been configured by rez_pip.
     :return:
         dict of rez packages created per python version: ``{"pythonVersion": PackageMaker()}``
@@ -150,7 +149,6 @@ def run_full_installation(
                 rez.package_maker.PackageMaker,
                 importlib_metadata.Distribution,
                 rez.version.Version,
-                bool,
             ],
             None,
         ]
@@ -173,7 +171,7 @@ def run_full_installation(
         filesystem path to an existing directory that can be used for pip to install packages.
     :param rezPackageCreationCallback:
         a function that is called for each rez package created, signature is as follows:
-        ``callable("package being created", "pip distribution", "python version", "being released")``.
+        ``callable("package being created", "pip distribution", "python version")``.
         It is being called after the package has been configured by rez_pip.
     :return:
         dict of rez packages created per python version: ``{"pythonVersion": PackageMaker()}``

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -121,7 +121,7 @@ def run_full_installation(
                 pipPackageNames,
                 str(pipPath),
                 pythonVersion,
-                os.fspath(pythonExecutable),
+                str(pythonExecutable),
                 requirementPath or [],
                 constraintPath or [],
                 pipArgs or [],

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -23,6 +23,117 @@ import rez_pip.exceptions
 _LOG = logging.getLogger(__name__)
 
 
+def run_installation_for_python(
+    pipPackageNames: typing.List[str],
+    pythonExecutable: pathlib.Path,
+    pythonVersion: str,
+    pipPath: pathlib.Path,
+    pipWorkArea: pathlib.Path,
+    pipArgs: typing.Optional[typing.List[str]] = None,
+    requirementPath: typing.Optional[typing.List[str]] = None,
+    constraintPath: typing.Optional[typing.List[str]] = None,
+    rezInstallPath: typing.Optional[str] = None,
+    rezRelease: bool = False,
+    rezPackageCreationCallback: typing.Optional[
+        typing.Callable[
+            [
+                rez.package_maker.PackageMaker,
+                importlib_metadata.Distribution,
+                rez.version.Version,
+                bool,
+            ],
+            None,
+        ]
+    ] = None,
+) -> typing.List[rez.package_maker.PackageMaker]:
+    """
+    Convert and install the given pip packages to rez packages using the given python version.
+
+    :param pipPackageNames: list of packages to install, in the syntax understood by pip.
+    :param pythonExecutable: filesystem path to an existing python interpreter
+    :param pythonVersion: a full rez version of the python package provided as executable
+    :param pipPath: filesystem path to the pip executable. If not provided use the bundled pip.
+    :param requirementPath: optional filesystem path to an existing python requirement file.
+    :param constraintPath: optional filesystem path to an existing python constraint file.
+    :param rezInstallPath:
+        optional filesystem path to an existing directory where to install the packages.
+        Default is the "local_packages_path".
+    :param rezRelease: True to release the package to the "release_packages_path"
+    :param pipArgs: additional argument passed directly to pip
+    :param pipWorkArea:
+        filesystem path to an existing directory that can be used for pip to install packages.
+    :param rezPackageCreationCallback:
+        a function that is called for each rez package created, signature is as follows:
+        ``callable("package being created", "pip distribution", "python version", "being released")``.
+        It is being called after the package has been configured by rez_pip.
+    :return:
+        dict of rez packages created per python version: ``{"pythonVersion": PackageMaker()}``
+        Note the PackageMaker object are already "close" and written to disk.
+    """
+    wheelsDir = pipWorkArea / "wheels"
+    os.makedirs(wheelsDir, exist_ok=True)
+
+    # Suffix with the python version because we loop over multiple versions,
+    # and package versions, content, etc can differ for each Python version.
+    installedWheelsDir = pipWorkArea / "installed" / pythonVersion
+    os.makedirs(installedWheelsDir, exist_ok=True)
+
+    with rich.get_console().status(
+        f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(pipPackageNames))} (python-{pythonVersion})"
+    ):
+        pipPackages = rez_pip.pip.getPackages(
+            pipPackageNames,
+            str(pipPath),
+            pythonVersion,
+            str(pythonExecutable),
+            requirementPath or [],
+            constraintPath or [],
+            pipArgs or [],
+        )
+
+    _LOG.info(f"Resolved {len(pipPackages)} dependencies for python {pythonVersion}")
+
+    # TODO: Should we postpone downloading to the last minute if we can?
+    _LOG.info("[bold]Downloading...")
+    wheels = rez_pip.download.downloadPackages(pipPackages, str(wheelsDir))
+    _LOG.info(f"[bold]Downloaded {len(wheels)} wheels")
+
+    dists: typing.Dict[importlib_metadata.Distribution, bool] = {}
+
+    with rich.get_console().status(
+        f"[bold]Installing wheels into {installedWheelsDir!r}"
+    ):
+        for package, wheel in zip(pipPackages, wheels):
+            _LOG.info(f"[bold]Installing {package.name}-{package.version} wheel")
+            dist, isPure = rez_pip.install.installWheel(
+                package, pathlib.Path(wheel), str(installedWheelsDir)
+            )
+
+            dists[dist] = isPure
+
+    distNames = [dist.name for dist in dists.keys()]
+
+    rezPackages = []
+
+    with rich.get_console().status("[bold]Creating rez packages..."):
+        for dist, package in zip(dists, pipPackages):
+            isPure = dists[dist]
+            rezPackage = rez_pip.rez.createPackage(
+                dist,
+                isPure,
+                rez.version.Version(pythonVersion),
+                distNames,
+                str(installedWheelsDir),
+                wheelURL=package.download_info.url,
+                prefix=rezInstallPath,
+                release=rezRelease,
+                creationCallback=rezPackageCreationCallback,
+            )
+            rezPackages.append(rezPackage)
+
+    return rezPackages
+
+
 def run_full_installation(
     pipPackageNames: typing.List[str],
     pythonVersionRange: typing.Optional[str],
@@ -46,7 +157,7 @@ def run_full_installation(
     ] = None,
 ) -> typing.Dict[str, typing.List[rez.package_maker.PackageMaker]]:
     """
-    Convert and install the given pip packages to rez packages compatible with the given python versions.
+    Convert and install the given pip packages to rez packages using the given python versions.
 
     :param pipPackageNames: list of packages to install, in the syntax understood by pip.
     :param pythonVersionRange: a single or range of python versions in the rez syntax.
@@ -83,66 +194,19 @@ def run_full_installation(
         _LOG.info(
             f"[bold underline]Installing requested packages for Python {pythonVersion}"
         )
-
-        wheelsDir = pipWorkArea / "wheels"
-        os.makedirs(wheelsDir, exist_ok=True)
-
-        # Suffix with the python version because we loop over multiple versions,
-        # and package versions, content, etc can differ for each Python version.
-        installedWheelsDir = pipWorkArea / "installed" / pythonVersion
-        os.makedirs(installedWheelsDir, exist_ok=True)
-
-        with rich.get_console().status(
-            f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(pipPackageNames))} (python-{pythonVersion})"
-        ):
-            pipPackages = rez_pip.pip.getPackages(
-                pipPackageNames,
-                str(pipPath),
-                pythonVersion,
-                str(pythonExecutable),
-                requirementPath or [],
-                constraintPath or [],
-                pipArgs or [],
-            )
-
-        _LOG.info(
-            f"Resolved {len(pipPackages)} dependencies for python {pythonVersion}"
+        packages = run_installation_for_python(
+            pipPackageNames=pipPackageNames,
+            pythonExecutable=pythonExecutable,
+            pythonVersion=pythonVersion,
+            pipPath=pipPath,
+            pipWorkArea=pipWorkArea,
+            pipArgs=pipArgs,
+            requirementPath=requirementPath,
+            constraintPath=constraintPath,
+            rezInstallPath=rezInstallPath,
+            rezRelease=rezRelease,
+            rezPackageCreationCallback=rezPackageCreationCallback,
         )
-
-        # TODO: Should we postpone downloading to the last minute if we can?
-        _LOG.info("[bold]Downloading...")
-        wheels = rez_pip.download.downloadPackages(pipPackages, str(wheelsDir))
-        _LOG.info(f"[bold]Downloaded {len(wheels)} wheels")
-
-        dists: typing.Dict[importlib_metadata.Distribution, bool] = {}
-
-        with rich.get_console().status(
-            f"[bold]Installing wheels into {installedWheelsDir!r}"
-        ):
-            for package, wheel in zip(pipPackages, wheels):
-                _LOG.info(f"[bold]Installing {package.name}-{package.version} wheel")
-                dist, isPure = rez_pip.install.installWheel(
-                    package, pathlib.Path(wheel), str(installedWheelsDir)
-                )
-
-                dists[dist] = isPure
-
-        distNames = [dist.name for dist in dists.keys()]
-
-        with rich.get_console().status("[bold]Creating rez packages..."):
-            for dist, package in zip(dists, pipPackages):
-                isPure = dists[dist]
-                rezPackage = rez_pip.rez.createPackage(
-                    dist,
-                    isPure,
-                    rez.version.Version(pythonVersion),
-                    distNames,
-                    str(installedWheelsDir),
-                    wheelURL=package.download_info.url,
-                    prefix=rezInstallPath,
-                    release=rezRelease,
-                    creationCallback=rezPackageCreationCallback,
-                )
-                rezPackages.setdefault(pythonVersion, []).append(rezPackage)
+        rezPackages[pythonVersion] = packages
 
     return rezPackages

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -24,7 +24,7 @@ _LOG = logging.getLogger(__name__)
 
 
 def pip_install_packages(
-    pipPackages: typing.List[str],
+    pipPackageNames: typing.List[str],
     pythonVersion: str,
     pythonExecutable: pathlib.Path,
     pipPath: pathlib.Path,
@@ -37,7 +37,7 @@ def pip_install_packages(
     """
     Install the given pip packages for the given python version using their wheels.
 
-    :param pipPackages: list of packages name to install, in the syntax understood by pip.
+    :param pipPackageNames: list of packages name to install, in the syntax understood by pip.
     :param pythonVersion: exact python rez package version (absolute version).
     :param pythonExecutable:
         filesystem path to the python executable corresponding to the given version
@@ -53,10 +53,10 @@ def pip_install_packages(
         ``dict[Distribution(), isPurePythonPackage]``
     """
     with rich.get_console().status(
-        f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(pipPackages))} (python-{pythonVersion})"
+        f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(pipPackageNames))} (python-{pythonVersion})"
     ):
         pipPackages = rez_pip.pip.getPackages(
-            pipPackages,
+            pipPackageNames,
             str(pipPath),
             pythonVersion,
             os.fspath(pythonExecutable),
@@ -89,7 +89,7 @@ def pip_install_packages(
 
 
 def run_full_installation(
-    pipPackages: typing.List[str],
+    pipPackageNames: typing.List[str],
     pythonVersionRange: typing.Optional[str],
     pipPath: pathlib.Path,
     pipWorkArea: pathlib.Path,
@@ -102,7 +102,7 @@ def run_full_installation(
     """
     Convert the given pip packages to rez packages compatibe with the given python versions.
 
-    :param pipPackages: list of packages name to install, in the syntax understood by pip.
+    :param pipPackageNames: list of packages name to install, in the syntax understood by pip.
     :param pythonVersionRange: a single or range of python versions in the rez syntax
     :param pipPath: filesystem path to the pip executable. If not provided use the bundled pip.
     :param requirementPath: optional filesystem path to an existing python requirement file.
@@ -143,7 +143,7 @@ def run_full_installation(
         os.makedirs(installedWheelsDir, exist_ok=True)
 
         dists = pip_install_packages(
-            pipPackages=pipPackages,
+            pipPackageNames=pipPackageNames,
             pythonVersion=pythonVersion,
             pythonExecutable=pythonExecutable,
             pipPath=pipPath,
@@ -157,7 +157,7 @@ def run_full_installation(
         distNames = [dist.name for dist in dists.keys()]
 
         with rich.get_console().status("[bold]Creating rez packages..."):
-            for dist, package in zip(dists, pipPackages):
+            for dist, package in zip(dists, pipPackageNames):
                 isPure = dists[dist]
                 rezPackage = rez_pip.rez.createPackage(
                     dist,

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -24,15 +24,15 @@ _LOG = logging.getLogger(__name__)
 
 
 def pip_install_packages(
-    pipPackages: list[str],
+    pipPackages: typing.List[str],
     pythonVersion: str,
     pythonExecutable: pathlib.Path,
     pipPath: pathlib.Path,
     wheelsDir: pathlib.Path,
     installedWheelsDir: pathlib.Path,
     pipArgs: typing.Optional[typing.List[str]] = None,
-    requirementPath: typing.Optional[list[str]] = None,
-    constraintPath: typing.Optional[list[str]] = None,
+    requirementPath: typing.Optional[typing.List[str]] = None,
+    constraintPath: typing.Optional[typing.List[str]] = None,
 ) -> typing.Dict[importlib_metadata.Distribution, bool]:
     """
     Install the given pip packages for the given python version using their wheels.
@@ -89,13 +89,13 @@ def pip_install_packages(
 
 
 def rez_install_pip_packages(
-    pipPackages: list[str],
+    pipPackages: typing.List[str],
     pythonVersionRange: typing.Optional[str],
     pipPath: pathlib.Path,
     pipWorkArea: pathlib.Path,
     pipArgs: typing.Optional[typing.List[str]] = None,
-    requirementPath: typing.Optional[list[str]] = None,
-    constraintPath: typing.Optional[list[str]] = None,
+    requirementPath: typing.Optional[typing.List[str]] = None,
+    constraintPath: typing.Optional[typing.List[str]] = None,
     rezInstallPath: typing.Optional[str] = None,
     rezRelease: bool = False,
 ) -> typing.Dict[str, rez.package_maker.PackageMaker]:

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -70,7 +70,7 @@ def run_full_installation(
     constraintPath: typing.Optional[typing.List[str]] = None,
     rezInstallPath: typing.Optional[str] = None,
     rezRelease: bool = False,
-) -> typing.Dict[str, rez.package_maker.PackageMaker]:
+) -> typing.Dict[str, typing.List[rez.package_maker.PackageMaker]]:
     """
     Convert the given pip packages to rez packages compatibe with the given python versions.
 
@@ -99,7 +99,7 @@ def run_full_installation(
             f'No "python" package found within the range {pythonVersionRange!r}.'
         )
 
-    rezPackages: typing.Dict[str, rez.package_maker.PackageMaker] = {}
+    rezPackages: typing.Dict[str, typing.List[rez.package_maker.PackageMaker]] = {}
 
     for pythonVersion, pythonExecutable in pythonVersions.items():
         _LOG.info(

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -62,7 +62,7 @@ def pip_install_packages(
             os.fspath(pythonExecutable),
             requirementPath or [],
             constraintPath or [],
-            pipArgs,
+            pipArgs or [],
         )
 
     _LOG.info(f"Resolved {len(pipPackages)} dependencies for python {pythonVersion}")

--- a/src/rez_pip/main.py
+++ b/src/rez_pip/main.py
@@ -26,12 +26,12 @@ def rez_install_pip_packages(
     pipPackages: list[str],
     pythonVersionRange: typing.Optional[str],
     pipPath: str,
-    requirementPath: typing.Optional[list[str]],
-    constraintPath: typing.Optional[list[str]],
-    rezInstallPath: typing.Optional[str],
-    rezRelease: bool,
-    pipArgs: typing.Optional[typing.List[str]],
     pipWorkArea: str,
+    pipArgs: typing.Optional[typing.List[str]] = None,
+    requirementPath: typing.Optional[list[str]] = None,
+    constraintPath: typing.Optional[list[str]] = None,
+    rezInstallPath: typing.Optional[str] = None,
+    rezRelease: bool = False,
 ) -> None:
     """
     Convert the given pip packages to rez packages compatibe with the given python versions.

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -33,6 +33,17 @@ def createPackage(
     wheelURL: str,
     prefix: typing.Optional[str] = None,
     release: bool = False,
+    creationCallback: typing.Optional[
+        typing.Callable[
+            [
+                rez.package_maker.PackageMaker,
+                importlib_metadata.Distribution,
+                rez.version.Version,
+                bool,
+            ],
+            None,
+        ]
+    ] = None,
 ) -> rez.package_maker.PackageMaker:
     _LOG.info(f"Creating rez package for {dist.name}")
     name = rez_pip.utils.pythontDistributionNameToRez(dist.name)
@@ -125,6 +136,9 @@ def createPackage(
             setattr(pkg, key, values)
 
         pkg.pip["metadata"] = remainingMetadata
+
+        if creationCallback is not None:
+            creationCallback(pkg, dist, pythonVersion, release)
 
     _LOG.info(
         f"[bold]Created {len(pkg.installed_variants)} variants and skipped {len(pkg.skipped_variants)}"

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -33,7 +33,7 @@ def createPackage(
     wheelURL: str,
     prefix: typing.Optional[str] = None,
     release: bool = False,
-) -> None:
+) -> rez.package_maker.PackageMaker:
     _LOG.info(f"Creating rez package for {dist.name}")
     name = rez_pip.utils.pythontDistributionNameToRez(dist.name)
     version = rez_pip.utils.pythonDistributionVersionToRez(dist.version)
@@ -129,6 +129,7 @@ def createPackage(
     _LOG.info(
         f"[bold]Created {len(pkg.installed_variants)} variants and skipped {len(pkg.skipped_variants)}"
     )
+    return pkg
 
 
 def _convertMetadata(

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -39,7 +39,6 @@ def createPackage(
                 rez.package_maker.PackageMaker,
                 importlib_metadata.Distribution,
                 rez.version.Version,
-                bool,
             ],
             None,
         ]
@@ -138,7 +137,7 @@ def createPackage(
         pkg.pip["metadata"] = remainingMetadata
 
         if creationCallback is not None:
-            creationCallback(pkg, dist, pythonVersion, release)
+            creationCallback(pkg, dist, pythonVersion)
 
     _LOG.info(
         f"[bold]Created {len(pkg.installed_variants)} variants and skipped {len(pkg.skipped_variants)}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,7 +193,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathF
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mocked:
+    with unittest.mock.patch("rez_pip.main.run_full_installation") as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -217,7 +217,7 @@ def test_run_removes_tmp_dirs_even_with_exceptions(
         return os.fspath(tmppath)
 
     with unittest.mock.patch(
-        "rez_pip.main.rez_install_pip_packages", side_effect=RuntimeError
+        "rez_pip.main.run_full_installation", side_effect=RuntimeError
     ) as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
@@ -243,7 +243,7 @@ def test_run_keep_tmp_dirs_even_with_exceptions(
         return os.fspath(tmppath)
 
     with unittest.mock.patch(
-        "rez_pip.main.rez_install_pip_packages", side_effect=RuntimeError
+        "rez_pip.main.run_full_installation", side_effect=RuntimeError
     ) as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
@@ -268,7 +268,7 @@ def test_run_keep_tmp_dirs(
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mocked:
+    with unittest.mock.patch("rez_pip.main.run_full_installation") as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -283,7 +283,7 @@ def test_run_keep_tmp_dirs(
 @pytest.mark.usefixtures("resetLogger")
 def test_run_with_debug_info(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(sys, "argv", ["rez-pip", "example", "--debug-info"])
-    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mockedRun:
+    with unittest.mock.patch("rez_pip.main.run_full_installation") as mockedRun:
         with unittest.mock.patch("rez_pip.cli._debug") as mockedDebug:
             assert rez_pip.cli.run() == 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,7 +193,7 @@ def test_run(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathF
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.cli._run") as mocked:
+    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -216,7 +216,9 @@ def test_run_removes_tmp_dirs_even_with_exceptions(
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.cli._run", side_effect=RuntimeError) as mocked:
+    with unittest.mock.patch(
+        "rez_pip.main.rez_install_pip_packages", side_effect=RuntimeError
+    ) as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -240,7 +242,9 @@ def test_run_keep_tmp_dirs_even_with_exceptions(
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.cli._run", side_effect=RuntimeError) as mocked:
+    with unittest.mock.patch(
+        "rez_pip.main.rez_install_pip_packages", side_effect=RuntimeError
+    ) as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -264,7 +268,7 @@ def test_run_keep_tmp_dirs(
     def mkdtemp(*args, **kwargs) -> str:
         return os.fspath(tmppath)
 
-    with unittest.mock.patch("rez_pip.cli._run") as mocked:
+    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mocked:
         with unittest.mock.patch(
             "rez_pip.cli.tempfile.mkdtemp", side_effect=mkdtemp
         ) as mockedMkdtemp:
@@ -279,7 +283,7 @@ def test_run_keep_tmp_dirs(
 @pytest.mark.usefixtures("resetLogger")
 def test_run_with_debug_info(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(sys, "argv", ["rez-pip", "example", "--debug-info"])
-    with unittest.mock.patch("rez_pip.cli._run") as mockedRun:
+    with unittest.mock.patch("rez_pip.main.rez_install_pip_packages") as mockedRun:
         with unittest.mock.patch("rez_pip.cli._debug") as mockedDebug:
             assert rez_pip.cli.run() == 0
 


### PR DESCRIPTION
> [!WARNING]
> Draft pull request, check back when its ready !

Hello,
I don't know if it was in the goal of rez_pip to be usable as a python library and not only as a CLI, but given its current "WIP" state I found myself in need of such behaviour so I could further custom rez_pip behaviour.

The goal is to have rez_pip part of a larger python script, doing the heavy work of installing pip package, but allowing to retrieve those for further manipulations.

# changes

⭐ Extract the `cli._run` private function to a new `main` module, as `run_full_installation` function.

> - **benefits**: 
>   - indirectly allow to clearly defined the "inputs" of the function that were hidden being the `args` variable from argparse before
>   - improve readability by using parameters with more complex names than ones defined in the CLI. 
>      examples: `pip` > `pipPath`, `packages` > `pipPackageNames`
> - **remarks**:
>   - are you satisfied with the name chosen for the new module + new function ?

⭐ Split `run_full_installation` into an additional lower-level function `run_installation_for_python`

> - **benefits**: 
>   - offer a workaround for #46 
>   - slightly increase readability by making `run_full_installation` lighter
>   - are you satisfied with the name chosen for the new function ?

have `rez.createPackage` return the `rez.package_maker.PackageMaker` object created

> - **benefits**:
>   - allow to further manipulate the package created if needed, or retrieve additional information from it

have new `run_full_installation` function return a dict of rez package created for each python version, dependent on previous change.

> - **benefits**:
>   - fit in the goal of allowing rez_pip to be part of a larger script that could use that ouput for further refinement.

⭐ add a `creationCallback` parameter to `rez.createPackage` and `main.run_full_installation` (in f7b6519ef2220c31d6561d302d5c043674436505)

> - **benefits**:
>   - allow to apply specific override per package when using rez_pip as a python library. This could help address some pitfalls of packaging pip packages to rez.
> - **remarks**:
>   - the 3 arguments provided to the callable were arbitrarily chosen based on their probability of use. Don't hesitate to comment if you think more or less should be provided. 

extract 2 functions from `rez.getPythonExecutables`: `getPythonExecutable` and `findPythonPackages`

> - **benefits**:
>   - improve readability by having smaller functions overall
>   - make it easier to re-use specific behavior when using rez_pip as library
> - **remarks**:
>   - do you think the change is pertinent ?

change some variable to be `pathlib.Path` objects instead of `str` (in 13b7ee41256f57eae1d1b58928757533027ab921 and a184ebf9a8d64f10d5c33f657ee9cf31cba6a558)

> - **benefits**:
>   - improve readability by clearly stating that we are expecting filesystem paths and not just strings.
>   - easier to use path related function on them (no need for os.path)
> - **remarks**:
>   - do you think the change is pertinent ?

# what to review

Not all those changes are necessary for the initial need. Do not hesitate to oppose to some of them if you think they are not pertinent.

Essential changes are marked with a ⭐ emoji.

# notes

I intended commit history to be pretty clean but I actually did some change I choose to revert later for maintaining simplicity.

# pitfalls

After a few test it seems rez_pip log/print system is not designed for a library use for now. But we could perhaps address those in another PR.

# misc suggestions

Not related to this PR but were found during the development process.

* remove `release` param from `rez.createPackage`, instead only use the `prefix` param to determine the path of the installation (that could also be renamed to be more explicit). 
* rename `rez.getPythonExecutables` to `getPythonExecutableFromRange` ?


# example

Here is a contextual use-case (in reference to issue #88 ):
```python
import logging
import shutil
import sys
import tempfile
from pathlib import Path

import rez.package_maker
import rez_pip.main
import rez_pip.pip

LOGGER = logging.getLogger(__name__)


def patch_cyclic_dependency(
    rez_package: rez.package_maker.PackageMaker,
    pip_distribution,
    python_version,
    is_released: bool,
):
    """
    Fix issue on some sphinx dependency that are required by ``sphinx`` but also require
    ``sphinx`` creating a cyclic dependency.

    We simply set a weak reference on all their ``requires`` to fix the issue.
    """
    if not rez_package.name.startswith("sphinx") or rez_package.name == "sphinx":
        return

    LOGGER.info(f"patching {rez_package.name}")
    rez_package.requires = ["~" + require for require in rez_package.requires]


def main():
    tmp_dir = Path(tempfile.mkdtemp(suffix="rez_pip"))
    tmp_dir = tmp_dir / "sphinx"
    tmp_dir.mkdir()

    LOGGER.info("calling rez_pip ...")
    installation = rez_pip.main.run_full_installation(
        pipPackageNames=["sphinx==7.2.6"],
        pythonVersionRange="==3.10.11",
        pipPath=Path(rez_pip.pip.getBundledPip()),
        pipWorkArea=tmp_dir,
        rezPackageCreationCallback=patch_cyclic_dependency,
    )
    LOGGER.info(
        f"installed {len([package for pyv, packages in installation.items() for package in packages])} packages"
    )

    shutil.rmtree(tmp_dir)


if __name__ == "__main__":
    # XXX rez_pip will go crazy if we override its logger
    _root_logger = logging.root
    logging.root = LOGGER
    logging.basicConfig(
        level=logging.INFO,
        format="{levelname: <7} | {asctime} [{name}] {message}",
        style="{",
        stream=sys.stdout,
    )
    logging.root = _root_logger
    main()
```

# todo

- [x] ensure existing tests succeed
- [x] ensure mypy suceed
- [ ] add tests for `run_full_installation`
