### PR TITLE
Use py-rattler instead of conda to create the python packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
+      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -k test_python_packages
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -k test_python_packages
+      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -k test_python_packages -vv
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
     - name: Test
-      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }} -- -k test_python_packages -vv
+      run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
 
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ dmypy.json
 .vscode
 /docs/build/
 tests/data/rez_repo/
-tests/data/_tmp_download/
+tests/data/_conda/
 docs/bin/
 .idea/
 /patches

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,7 +11,9 @@ addopts =
     --override-ini junit_family=legacy
     #--durations=0
 
-norecursedirs = rez_repo
+norecursedirs =
+    rez_repo
+    _conda
 
 markers =
     integration: mark the tests as integration tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,14 +180,14 @@ def rezRepo() -> typing.Generator[str, None, None]:
     scope="session",
     params=[
         pytest.param(
-            "3.7.12",
+            "3.7",
             marks=pytest.mark.py37,
         ),
         pytest.param(
-            "3.9.16",
+            "3.9",
             marks=pytest.mark.py39,
         ),
-        pytest.param("3.11.5", marks=pytest.mark.py311),
+        pytest.param("3.11", marks=pytest.mark.py311),
     ],
 )
 def pythonRezPackage(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,8 +236,9 @@ def pythonRezPackage(
             ]
             if platform.system() == "Windows":
                 commands = [
+                    "env.PATH.prepend('{root}/python/DLLs')",
                     "env.PATH.prepend('{root}/python/Library/bin')",
-                    "env.PATH.prepend('{root}/python/Library/lib')",
+                    "env.PATH.prepend('{root}/python')",
                 ]
 
             pkg.commands = "\n".join(commands)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,9 +254,9 @@ def pythonRezPackage(
 async def createCondaEnvironment(pythonVersion: str, prefixPath: str):
     """Create a conda environment using py-rattler"""
     records = await rattler.solve(
-        ["https://conda.anaconda.org/conda-forge"],
-        [rattler.MatchSpec(f"python={pythonVersion}")],
-        virtual_packages=[p.into_generic() for p in rattler.VirtualPackage.current()],
+        ["https://repo.anaconda.com/pkgs/main"],
+        [rattler.MatchSpec(f"python {pythonVersion}")],
+        virtual_packages=rattler.VirtualPackage.detect(),
     )
 
     await rattler.install(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,14 +180,20 @@ def rezRepo() -> typing.Generator[str, None, None]:
     scope="session",
     params=[
         pytest.param(
-            "3.7",
-            marks=pytest.mark.py37,
+            "3.7.16",
+            marks=[
+                pytest.mark.py3,
+                pytest.mark.skipif(
+                    platform.processor() == "arm" and platform.system() == "Darwin",
+                    reason="Python 3.7 is not compatible with Apple Silicon",
+                ),
+            ],
         ),
         pytest.param(
-            "3.9",
+            "3.9.21",
             marks=pytest.mark.py39,
         ),
-        pytest.param("3.11", marks=pytest.mark.py311),
+        pytest.param("3.11.11", marks=pytest.mark.py311),
     ],
 )
 def pythonRezPackage(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,7 +255,7 @@ async def createCondaEnvironment(pythonVersion: str, prefixPath: str):
     """Create a conda environment using py-rattler"""
     records = await rattler.solve(
         ["https://repo.anaconda.com/pkgs/main"],
-        [rattler.MatchSpec(f"python {pythonVersion}")],
+        [rattler.MatchSpec(f"python={pythonVersion}")],
         virtual_packages=rattler.VirtualPackage.detect(),
     )
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,4 @@ pytest-print
 pypiserver
 build
 hatchling
-git+https://github.com/conda/conda-package-handling@2.1.0; platform_system != "Windows"
-# 23.1.0 is the last version to support Python 3.7
-git+https://github.com/conda/conda@23.1.0; platform_system != "Windows"
+py-rattler

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -28,40 +28,44 @@ def test_python_packages(pythonRezPackage: str, rezRepo: str):
         [package.qualified_name], package_paths=[rezRepo]
     )
 
-    executable = f"python{str(package.version).split('.')[0]}"
-    if platform.system() == "Windows":
-        executable = "python.exe"
+    executableName = f"python{str(package.version).split('.')[0]}"
 
-    code, stdout, _ = ctx.execute_shell(
-        command=[executable, "--version"],
-        block=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-
-    assert code == 0
-    assert re.findall(r"\d\.\d+\.\d+", stdout.decode("utf-8"), flags=re.MULTILINE)[
-        0
-    ] == str(package.version)
-
-    code, stdout, _ = ctx.execute_shell(
-        command=[executable, "-c", "import sys; print(sys.executable)"],
-        block=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-    )
-
-    expectedPath = os.path.join(
+    expectedExecutablePath = os.path.join(
         rezRepo,
         "python",
         str(package.version),
         "python",
-        "tools" if platform.system() == "Windows" else "bin",
-        executable,
+    )
+
+    if platform.system() == "Windows":
+        executableName = "python.exe"
+        expectedExecutablePath = os.path.join(expectedExecutablePath, "Library")
+
+    expectedExecutablePath = os.path.join(expectedExecutablePath, "bin", executableName)
+
+    code, stdout, _ = ctx.execute_shell(
+        command=[executableName, "-c", "import sys; print(sys.executable)"],
+        block=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
     )
 
     assert code == 0
-    assert stdout.decode("utf-8").strip().lower() == expectedPath.lower()
+    assert stdout.strip().lower() == expectedExecutablePath.lower()
+
+    code, stdout, _ = ctx.execute_shell(
+        command=[executableName, "--version"],
+        block=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    assert code == 0
+    assert re.findall(r"\d\.\d+\.\d+", stdout, flags=re.MULTILINE)[0] == str(
+        package.version
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,9 +39,11 @@ def test_python_packages(pythonRezPackage: str, rezRepo: str):
 
     if platform.system() == "Windows":
         executableName = "python.exe"
-        expectedExecutablePath = os.path.join(expectedExecutablePath, "Library")
-
-    expectedExecutablePath = os.path.join(expectedExecutablePath, "bin", executableName)
+        expectedExecutablePath = os.path.join(expectedExecutablePath, executableName)
+    else:
+        expectedExecutablePath = os.path.join(
+            expectedExecutablePath, "bin", executableName
+        )
 
     code, stdout, _ = ctx.execute_shell(
         command=[executableName, "-c", "import sys; print(sys.executable)"],


### PR DESCRIPTION
Closes #121

`py-rattler` is the python biding for the rattler rust library. Rattler is much faster, and we can also more safely depend on it compared to conda since we can't "easily" pip install conda.