### PR TITLE
Add plugin system and local wheels support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+source_pkgs=rez_pip
+
+[report]
+exclude_also =
+    def __dir__
+    if TYPE_CHECKING:
+    if typing.TYPE_CHECKING:

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Denote all files that are truly binary and should not be modified.
+*.patch binary

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,6 @@ jobs:
 
     - name: Test
       run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
-      env:
-        TERM: dumb
 
     - name: Codecov upload
       uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,8 @@ jobs:
 
     - name: Test
       run: pipx run nox --error-on-missing-interpreter -s test-${{ matrix.python }}
+      env:
+        TERM: dumb
 
     - name: Codecov upload
       uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ tests/data/rez_repo/
 tests/data/_tmp_download/
 docs/bin/
 .idea/
+/patches

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -22,3 +22,6 @@ API
 
 .. autoclass:: rez_pip.pip.DownloadedArtifact
    :members:
+
+.. autoclass:: rez_pip.plugins.CleanupAction
+   :members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,24 @@
+===
+API
+===
+
+.. warning:: The API is only meant to be used by plugins authors.
+
+.. autoclass:: rez_pip.pip.T
+
+.. autoclass:: rez_pip.pip.DownloadInfo
+   :members:
+
+.. autoclass:: rez_pip.pip.Metadata
+   :members:
+   :undoc-members:
+
+.. autoclass:: rez_pip.pip.PackageInfo
+   :members:
+
+.. autoclass:: rez_pip.pip.PackageGroup
+   :members:
+   :show-inheritance:
+
+.. autoclass:: rez_pip.pip.DownloadedArtifact
+   :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,11 +63,12 @@ linkcheck_allowed_redirects = {
 # https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
 
 intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
     "rez": ("https://rez.readthedocs.io/en/stable/", None),
 }
 
 # Force usage of :external:
-intersphinx_disabled_reftypes = ["*"]
+# intersphinx_disabled_reftypes = ["*"]
 
 
 # -- Custom ------------------------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -326,14 +326,14 @@ class RezPipAutoPluginHooks(sphinx.util.docutils.SphinxDirective):
         klass = getattr(mod, klassname)
 
         methods = [
-            method[0]
+            method
             for method in inspect.getmembers(klass, predicate=inspect.isfunction)
             if not method[0].startswith("_")
         ]
 
         document = []
-        for method in methods:
-            document.append(f".. autohook:: {module}.{klassname}.{method}")
+        for method in sorted(methods, key=lambda x: x[1].__code__.co_firstlineno):
+            document.append(f".. autohook:: {module}.{klassname}.{method[0]}")
 
         document = "\n".join(document)
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,8 +4,31 @@ FAQ
 
 List of commonly asked questions.
 
-Why does the rez package created by rez-pip creates a variant per platform?
-===========================================================================
+Which packages does it support?
+===============================
+
+It technically supports all packages available on PyPI that are distributed as wheels.
+Packages that only provide an sdist are not supported.
+
+We say "technically" because there are some exceptions. Some packages on PyPI rely
+on DSOs (shared libraries, i.e. ``.so``/``.DLL``/``.dylib`` files) that are not available on
+all platforms. This is normal and is supported for most packages. However, there are some
+packages that rely on methods like adding paths using :func:`os.add_dll_directory` or
+hardcoded paths.
+
+Some others rely on `path configuration (.pth) files <https://docs.python.org/3/library/site.html>`_.
+
+When a package relies on these methods, rez-pip will successfully install it, but
+the package might not function correctly (either partly or entirely).
+
+The :doc:`plugin system <plugins>` was created to handled these cases. You can use plugins
+to modify the package metatada, patch source files, add/remove files, etc.
+
+``rez-pip`` comes with some :ref:`built-in plugins <plugins:built-in plugins>` for packages that are popular
+in our communities and are known to be "broken" when installed with ``rez-pip``.
+
+Why does the rez package created by rez-pip create a variant per platform?
+==========================================================================
 
 Sometimes rez-pip creates rez packages that have variants for the platform and arch on which they were installed,
 and sometimes it even creates variants for Python versions. Bellow are the scenarios

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Features
   create per python version variants when installing a package that has console scripts.
 * Better output logs.
 * Implemented as an out-of-tree plugin, which means faster development cycle and more frequent releases.
+* :doc:`Plugin system <plugins>` that allows for easy extensibility (experimental).
 * Maintained by the rez maintainers.
 
 Prerequisites

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -69,5 +69,6 @@ automatically created by the `install.py <https://github.com/AcademySoftwareFoun
    command
    transition
    metadata
+   plugins
    faq
    changelog

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,5 +70,6 @@ automatically created by the `install.py <https://github.com/AcademySoftwareFoun
    transition
    metadata
    plugins
+   api
    faq
    changelog

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -10,7 +10,7 @@ This page documents the hooks available to plugins and how to implement plugins.
 List installed plugins
 ======================
 
-To list all installed plugins, use the :option:`--list-plugins` command line argument.
+To list all installed plugins, use the :option:`rez-pip --list-plugins` command line argument.
 
 Register a plugin
 =================

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -26,9 +26,9 @@ Register a plugin
 rez-pip's plugin system is based on the `pluggy <https://pluggy.readthedocs.io/en/latest/>`_ framework,
 and as such, plugins must be registered using `entry points <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
 
-The entry point group is named `rez-pip`.
+The entry point group is named ``rez-pip``.
 
-In a `pyproject.toml` file, it can be set like this:
+In a ``pyproject.toml`` file, it can be set like this:
 
 .. code-block:: toml
    :caption: pyproject.toml
@@ -49,6 +49,9 @@ Functions
 
 Hooks
 =====
+
+The list of available hooks is provided below. They are listed in the order they
+are called by rez-pip.
 
 .. rez-pip-autopluginhooks:: rez_pip.plugins.PluginSpec
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -2,6 +2,14 @@
 Plugins
 =======
 
+.. versionadded:: 0.4.0
+
+.. warning::
+   Plugins are new and have not been tested througfully. There might be bugs, missing
+   features and rough edges.
+
+   We encourage you to try them out and report any issues you might find.
+
 rez-pip can be extended using plugins. Plugins can be used to do various things, such as
 modifying packages (both metadata and files), etc.
 
@@ -42,11 +50,8 @@ Functions
 Hooks
 =====
 
-.. autohook:: rez_pip.plugins.PluginSpec.prePipResolve
-.. autohook:: rez_pip.plugins.PluginSpec.postPipResolve
-.. autohook:: rez_pip.plugins.PluginSpec.groupPackages
-.. autohook:: rez_pip.plugins.PluginSpec.cleanup
-.. autohook:: rez_pip.plugins.PluginSpec.metadata
+.. rez-pip-autopluginhooks:: rez_pip.plugins.PluginSpec
+
 
 Built-in plugins
 ================
@@ -57,8 +62,3 @@ to fix packages that are known to be "broken" if we don't fix them using plugins
 This lists the plugin names and the hooks they implement.
 
 .. rez-pip-autoplugins::
-
-Example
-=======
-
-.. todo:: Add an example plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -42,3 +42,18 @@ Hooks
 .. autohook:: rez_pip.plugins.PluginSpec.groupPackages
 .. autohook:: rez_pip.plugins.PluginSpec.cleanup
 .. autohook:: rez_pip.plugins.PluginSpec.metadata
+
+Built-in plugins
+================
+
+rez-pip comes with some built-in plugins that are enabled by default. They exists mostly
+to fix packages that are known to be "broken" if we don't fix them using plugins.
+
+This lists the plugin names and the hooks they implement.
+
+.. rez-pip-autoplugins::
+
+Example
+=======
+
+.. todo:: Add an example plugin

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -10,6 +10,10 @@ Plugins
 
    We encourage you to try them out and report any issues you might find.
 
+   If you create your own plugins, expect them to break when you update
+   rez-pip's minor version. The plugin system is still in its early stages
+   and we will probably release breaking changes in the future.
+
 rez-pip can be extended using plugins. Plugins can be used to do various things, such as
 modifying packages (both metadata and files), etc.
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -1,0 +1,49 @@
+=======
+Plugins
+=======
+
+
+.. py:decorator:: rez_pip.plugins.hookimpl
+
+   Decorator used to register a plugin hook.
+
+Hooks
+=====
+
+.. py:function:: prePipResolve(packages: list[str], requirements: list[str]) -> None
+
+   The pre-pip resolve hook allows a plugin to run some checks *before* resolving the
+   requested packages using pip. The hook **must** not modify the content of the
+   arguments passed to it.
+
+   Some use cases are allowing or disallowing the installation of some packages.
+
+   :param packages: List of packages requested by the user.
+   :param requirements: List of `requirements files <https://pip.pypa.io/en/stable/reference/requirements-file-format/#requirements-file-format>`_ if any.
+
+.. py:function:: postPipResolve(packages: list[rez_pip.pip.PackageInfo]) -> None
+
+   The post-pip resolve hook allows a plugin to run some checks *after* resolving the
+   requested packages using pip. The hook **must** not modify the content of the
+   arguments passed to it.
+
+   Some use cases are allowing or disallowing the installation of some packages.
+
+   :param packages: List of resolved packages.
+
+.. py:function:: groupPackages(packages: list[rez_pip.pip.PackageInfo]) -> list[rez_pip.pip.PackageGroup]:
+
+   Merge packages into groups of packages. The name and version of the first package
+   in the group will be used as the name and version for the rez package.
+
+   The hook **must** pop grouped packages out of the "packages" variable.
+
+   :param packages: List of resolved packages.
+   :returns: A list of package groups.
+
+.. py:function:: metadata(package: rez.package_maker.PackageMaker) -> None
+
+   Modify/inject metadata in the rez package. The plugin is expected to modify
+   "package" in place.
+
+   :param package: An instanciate PackageMaker.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -47,3 +47,10 @@ Hooks
    "package" in place.
 
    :param package: An instanciate PackageMaker.
+
+.. py:function:: cleanup(dist: importlib.metadata.Distribution, path: str) -> None
+
+   Cleanup a package post-installation.
+
+   :param dist: Python distribution.
+   :param path: Root path of the rez variant.

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -7,6 +7,11 @@ modifying packages (both metadata and files), etc.
 
 This page documents the hooks available to plugins and how to implement plugins.
 
+List installed plugins
+======================
+
+To list all installed plugins, use the :option:`--list-plugins` command line argument.
+
 Register a plugin
 =================
 

--- a/docs/source/plugins.rst
+++ b/docs/source/plugins.rst
@@ -2,7 +2,34 @@
 Plugins
 =======
 
+rez-pip can be extended using plugins. Plugins can be used to do various things, such as
+modifying packages (both metadata and files), etc.
 
+This page documents the hooks available to plugins and how to implement plugins.
+
+Register a plugin
+=================
+
+rez-pip's plugin system is based on the `pluggy <https://pluggy.readthedocs.io/en/latest/>`_ framework,
+and as such, plugins must be registered using `entry points <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
+
+The entry point group is named `rez-pip`.
+
+In a `pyproject.toml` file, it can be set like this:
+
+.. code-block:: toml
+   :caption: pyproject.toml
+
+   [project.entry-points."rez-pip"]
+   my_plugin = "my_plugin_module"
+
+
+Functions
+=========
+
+.. Not Using autodoc here because the decorator has a complex
+   signature to help type hinters. That signature is not needed
+   for the end user.
 .. py:decorator:: rez_pip.plugins.hookimpl
 
    Decorator used to register a plugin hook.
@@ -10,47 +37,8 @@ Plugins
 Hooks
 =====
 
-.. py:function:: prePipResolve(packages: list[str], requirements: list[str]) -> None
-
-   The pre-pip resolve hook allows a plugin to run some checks *before* resolving the
-   requested packages using pip. The hook **must** not modify the content of the
-   arguments passed to it.
-
-   Some use cases are allowing or disallowing the installation of some packages.
-
-   :param packages: List of packages requested by the user.
-   :param requirements: List of `requirements files <https://pip.pypa.io/en/stable/reference/requirements-file-format/#requirements-file-format>`_ if any.
-
-.. py:function:: postPipResolve(packages: list[rez_pip.pip.PackageInfo]) -> None
-
-   The post-pip resolve hook allows a plugin to run some checks *after* resolving the
-   requested packages using pip. The hook **must** not modify the content of the
-   arguments passed to it.
-
-   Some use cases are allowing or disallowing the installation of some packages.
-
-   :param packages: List of resolved packages.
-
-.. py:function:: groupPackages(packages: list[rez_pip.pip.PackageInfo]) -> list[rez_pip.pip.PackageGroup]:
-
-   Merge packages into groups of packages. The name and version of the first package
-   in the group will be used as the name and version for the rez package.
-
-   The hook **must** pop grouped packages out of the "packages" variable.
-
-   :param packages: List of resolved packages.
-   :returns: A list of package groups.
-
-.. py:function:: metadata(package: rez.package_maker.PackageMaker) -> None
-
-   Modify/inject metadata in the rez package. The plugin is expected to modify
-   "package" in place.
-
-   :param package: An instanciate PackageMaker.
-
-.. py:function:: cleanup(dist: importlib.metadata.Distribution, path: str) -> None
-
-   Cleanup a package post-installation.
-
-   :param dist: Python distribution.
-   :param path: Root path of the rez variant.
+.. autohook:: rez_pip.plugins.PluginSpec.prePipResolve
+.. autohook:: rez_pip.plugins.PluginSpec.postPipResolve
+.. autohook:: rez_pip.plugins.PluginSpec.groupPackages
+.. autohook:: rez_pip.plugins.PluginSpec.cleanup
+.. autohook:: rez_pip.plugins.PluginSpec.metadata

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -59,3 +59,86 @@ Since pip is used under the hood, pip can be configured as usual. See the `pip c
 for more information on the subject. Alternatively, you can also :ref:`pass custom command line arguments to pip <user_guide:passing arguments to pip directly>`.
 
 .. _pip configuration documentation: https://pip.pypa.io/en/stable/topics/configuration/
+
+Writing a plugin
+================
+
+As documented in :ref:`plugins:register a plugin`, plugins must be registered using entry points.
+This also means that your plugin will have to be packaged using standard Python packaging tools.
+
+.. note:: Even if you package it using standard Python packaging tools, you won't need
+          to distribute it to PyPI.
+
+Our plugin will have the following file structure:
+
+.. code-block:: text
+
+   my_plugin/
+   ├── pyproject.toml
+   └── src/
+       └── my_plugin/
+           └── __init__.py
+
+In ``pyproject.toml``, we will define our package and plugin entry point:
+
+.. code-block:: toml
+   :caption: pyproject.toml
+
+   [project]
+   name = "my_plugin"
+   version = "0.1.0"
+
+   [project.entry-points."rez-pip"]
+   my_plugin = "my_plugin"
+
+   [build-system]
+   requires = ["hatchling"]
+   build-backend = "hatchling.build"
+
+This is the absolute minimum required to create a plugin. For more details
+on how to package a python project, please refer to `the official documentation`_.
+
+.. _the official documentation: https://packaging.python.org/en/latest/tutorials/packaging-projects/
+
+Now that this is out of the way, let's write our plugin.
+
+.. code-block:: python
+   :caption: src/my_plugin/__init__.py
+
+   import logging
+
+   import rez_pip.plugins
+   import rez.package_maker
+
+   _LOG = logging.getLogger(__name__)
+
+
+   @rez_pip.plugins.hookimpl
+   def metadata(package: rez.package_maker.PackageMaker) -> None
+       _LOG.info(
+           "Adding my_custom_attr to the package definition of %s %s",
+           package.name,
+           package.version,
+       )
+       package.my_custom_attr = "my_custom_value"
+
+.. tip::
+   :name: Logs
+
+   It is highly recommended to add logs to your plugins. You can use :func:`logging.getLogger`
+   to get a pre-configured logger. Make sure to pass a unique name to the logger.
+
+   Your logs should clearly describe what your plugin is doing. If your plugin modifies
+   something, then it should log that. If it is just reading something, then you might
+   not need to log.
+
+The plugin we defined in ``src/my_plugin/__init__.py`` registers a hook called ``metadata`` that
+modifies the package definition. More particularly, it adds an attribute called ``my_custom_attr``
+to the package definition. Here we use a dummy attribute name just to illustrate the concept.
+But this is a common scenario.
+
+For brevity, we only implement one hook. ``rez-pip`` provides many other hooks that you can implement.
+Hooks are documented in :ref:`plugins:hooks`.
+
+Once this is done, you can test your plugin by installing it. For example, you can use ``pip install -e .``
+to install it in `editable mode <https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dependencies = [
     "dataclasses-json",
     "rich",
     "importlib_metadata>=4.6 ; python_version < '3.10'",
+    # 1.3 introduces type hints.
+    "pluggy>=1.3"
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ dependencies = [
     "importlib_metadata>=4.6 ; python_version < '3.10'",
     # 1.3 introduces type hints.
     "pluggy>=1.2",
-    "typing-extensions; python_version < '3.8'"
+    "typing-extensions; python_version < '3.8'",
+    # Patches are finicky... Let's lock on the current latest version.
+    # We could always relax later if needed.
+    "patch-ng==1.18.1",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "rich",
     "importlib_metadata>=4.6 ; python_version < '3.10'",
     # 1.3 introduces type hints.
-    "pluggy>=1.3"
+    "pluggy>=1.2",
 ]
 
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "importlib_metadata>=4.6 ; python_version < '3.10'",
     # 1.3 introduces type hints.
     "pluggy>=1.2",
+    "typing-extensions; python_version < '3.8'"
 ]
 
 classifiers = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,5 +14,5 @@ norecursedirs = rez_repo
 markers =
     integration: mark the tests as integration tests
     py37: mark the tests has using a Python 3.7 rez package
-    py39: mark the tests has using a Python 3.7 rez package
+    py39: mark the tests has using a Python 3.9 rez package
     py311: mark the tests has using a Python 3.11 rez package

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,7 +7,7 @@ addopts =
     --cov-report=term-missing
     --cov-report=xml
     --cov-report=html
-    --durations=0
+    #--durations=0
 
 norecursedirs = rez_repo
 

--- a/scripts/get_pyside6_files.py
+++ b/scripts/get_pyside6_files.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import os
+import ast
+import sys
+import bisect
+import typing
+import difflib
+import zipfile
+import tempfile
+import itertools
+import contextlib
+import subprocess
+
+import requests
+import requests.models
+import packaging.utils
+
+
+# Token from https://github.com/pypa/pip/blob/bc553db53c264abe3bb63c6bcd6fc6f303c6f6e3/src/pip/_internal/network/lazy_wheel.py
+class LazyZipOverHTTP:
+    """File-like object mapped to a ZIP file over HTTP.
+
+    This uses HTTP range requests to lazily fetch the file's content,
+    which is supposed to be fed to ZipFile.  If such requests are not
+    supported by the server, raise HTTPRangeRequestUnsupported
+    during initialization.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        session: requests.Session,
+        chunk_size: int = requests.models.CONTENT_CHUNK_SIZE,
+    ) -> None:
+        head = session.head(url, headers={"Accept-Encoding": "identity"})
+        head.raise_for_status()
+        assert head.status_code == 200
+        self._session, self._url, self._chunk_size = session, url, chunk_size
+        self._length = int(head.headers["Content-Length"])
+        self._file = tempfile.NamedTemporaryFile()
+        self.truncate(self._length)
+        self._left: typing.List[int] = []
+        self._right: typing.List[int] = []
+        if "bytes" not in head.headers.get("Accept-Ranges", "none"):
+            raise ValueError("range request is not supported")
+        self._check_zip()
+
+    @property
+    def mode(self) -> str:
+        """Opening mode, which is always rb."""
+        return "rb"
+
+    @property
+    def name(self) -> str:
+        """Path to the underlying file."""
+        return self._file.name
+
+    def seekable(self) -> bool:
+        """Return whether random access is supported, which is True."""
+        return True
+
+    def close(self) -> None:
+        """Close the file."""
+        self._file.close()
+
+    @property
+    def closed(self) -> bool:
+        """Whether the file is closed."""
+        return self._file.closed
+
+    def read(self, size: int = -1) -> bytes:
+        """Read up to size bytes from the object and return them.
+
+        As a convenience, if size is unspecified or -1,
+        all bytes until EOF are returned.  Fewer than
+        size bytes may be returned if EOF is reached.
+        """
+        download_size = max(size, self._chunk_size)
+        start, length = self.tell(), self._length
+        stop = length if size < 0 else min(start + download_size, length)
+        start = max(0, stop - download_size)
+        self._download(start, stop - 1)
+        return self._file.read(size)
+
+    def readable(self) -> bool:
+        """Return whether the file is readable, which is True."""
+        return True
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        """Change stream position and return the new absolute position.
+
+        Seek to offset relative position indicated by whence:
+        * 0: Start of stream (the default).  pos should be >= 0;
+        * 1: Current position - pos may be negative;
+        * 2: End of stream - pos usually negative.
+        """
+        return self._file.seek(offset, whence)
+
+    def tell(self) -> int:
+        """Return the current position."""
+        return self._file.tell()
+
+    def truncate(self, size: typing.Optional[int] = None) -> int:
+        """Resize the stream to the given size in bytes.
+
+        If size is unspecified resize to the current position.
+        The current stream position isn't changed.
+
+        Return the new file size.
+        """
+        return self._file.truncate(size)
+
+    def writable(self) -> bool:
+        """Return False."""
+        return False
+
+    def __enter__(self) -> "LazyZipOverHTTP":
+        self._file.__enter__()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._file.__exit__(*exc)
+
+    @contextlib.contextmanager
+    def _stay(self) -> typing.Generator[None, None, None]:
+        """Return a context manager keeping the position.
+
+        At the end of the block, seek back to original position.
+        """
+        pos = self.tell()
+        try:
+            yield
+        finally:
+            self.seek(pos)
+
+    def _check_zip(self) -> None:
+        """Check and download until the file is a valid ZIP."""
+        end = self._length - 1
+        for start in reversed(range(0, end, self._chunk_size)):
+            self._download(start, end)
+            with self._stay():
+                try:
+                    # For read-only ZIP files, ZipFile only needs
+                    # methods read, seek, seekable and tell.
+                    zipfile.ZipFile(self)
+                except zipfile.BadZipFile:
+                    pass
+                else:
+                    break
+
+    def _stream_response(
+        self,
+        start: int,
+        end: int,
+        base_headers: typing.Dict[str, str] = {"Accept-Encoding": "identity"},
+    ) -> requests.Response:
+        """Return HTTP response to a range request from start to end."""
+        headers = base_headers.copy()
+        headers["Range"] = f"bytes={start}-{end}"
+        # TODO: Get range requests to be correctly cached
+        headers["Cache-Control"] = "no-cache"
+        return self._session.get(self._url, headers=headers, stream=True)
+
+    def _merge(
+        self, start: int, end: int, left: int, right: int
+    ) -> typing.Generator[typing.Tuple[int, int], None, None]:
+        """Return a generator of intervals to be fetched.
+
+        Args:
+            start (int): Start of needed interval
+            end (int): End of needed interval
+            left (int): Index of first overlapping downloaded data
+            right (int): Index after last overlapping downloaded data
+        """
+        lslice, rslice = self._left[left:right], self._right[left:right]
+        i = start = min([start] + lslice[:1])
+        end = max([end] + rslice[-1:])
+        for j, k in zip(lslice, rslice):
+            if j > i:
+                yield i, j - 1
+            i = k + 1
+        if i <= end:
+            yield i, end
+        self._left[left:right], self._right[left:right] = [start], [end]
+
+    def _download(self, start: int, end: int) -> None:
+        """Download bytes from start to end inclusively."""
+        with self._stay():
+            left = bisect.bisect_left(self._right, start)
+            right = bisect.bisect_right(self._left, end)
+            for start, end in self._merge(start, end, left, right):
+                response = self._stream_response(start, end)
+                response.raise_for_status()
+                self.seek(start)
+                for chunk in response.iter_content(self._chunk_size):
+                    self._file.write(chunk)
+
+
+# https://stackoverflow.com/a/66733795
+def compare_ast(
+    node1: ast.expr | list[ast.expr], node2: ast.expr | list[ast.expr]
+) -> bool:
+    if type(node1) is not type(node2):
+        return False
+
+    if isinstance(node1, ast.AST):
+        for k, v in vars(node1).items():
+            if k in {"lineno", "end_lineno", "col_offset", "end_col_offset", "ctx"}:
+                continue
+            if not compare_ast(v, getattr(node2, k)):
+                return False
+        return True
+
+    elif isinstance(node1, list) and isinstance(node2, list):
+        return all(
+            compare_ast(n1, n2) for n1, n2 in itertools.zip_longest(node1, node2)
+        )
+    else:
+        return node1 == node2
+
+
+def run():
+    with requests.get(
+        "https://pypi.org/simple/pyside6",
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+    ) as resp:
+        resp.raise_for_status()
+
+        data = resp.json()
+
+    versions: list[str] = []
+    for entry in data["files"]:
+        if not entry["filename"].endswith(".whl"):
+            continue
+
+        name, version, buildtag, tags = packaging.utils.parse_wheel_filename(
+            entry["filename"]
+        )
+        if version.pre:
+            continue
+
+        if not any(
+            tag.platform.startswith("win_") and not tag.interpreter.startswith("pp")
+            for tag in tags
+        ):
+            continue
+
+        print(entry["filename"])
+
+        # Store raw files in patches/data/<wheel>
+        # This will allow us ot inspect them before deciding on how
+        # to create patches.
+
+        directory = os.path.join("patches", "data", str(version))
+        os.makedirs(directory, exist_ok=True)
+
+        session = requests.Session()
+        wheel = LazyZipOverHTTP(entry["url"], session)
+        with zipfile.ZipFile(wheel) as zf:
+            for info in zf.infolist():
+                if info.filename != "PySide6/__init__.py":
+                    continue
+
+                with open(
+                    os.path.join(directory, os.path.basename(info.filename)), "wb"
+                ) as f:
+                    f.write(zf.read(info))
+                break
+
+        versions.append(str(version))
+
+    print("Comparing files")
+    first = versions.pop(0)
+
+    while len(versions) > 1:
+        leftFile = f"patches/data/{versions[0]}/__init__.py"
+        rightFile = f"patches/data/{versions[1]}/__init__.py"
+        with open(leftFile, "r") as lfh, open(rightFile, "r") as rfh:
+            lhs = ast.parse(lfh.read())
+            rhs = ast.parse(rfh.read())
+
+        leftAST = next(
+            node
+            for node in lhs.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_additional_dll_directories"
+        )
+
+        rightAST = next(
+            node
+            for node in rhs.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_additional_dll_directories"
+        )
+
+        if not compare_ast(leftAST, rightAST):
+            print(
+                f"{versions[0]} and {versions[1]}'s _additional_dll_directories function differ"
+            )
+            leftCode = ast.unparse(leftAST).splitlines(keepends=True)
+            rightCode = ast.unparse(rightAST).splitlines(keepends=True)
+
+            result = difflib.unified_diff(
+                leftCode, rightCode, fromfile=leftFile, tofile=rightFile
+            )
+
+            sys.stdout.writelines(result)
+
+        versions.pop(0)
+
+
+run()

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 import json

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -213,7 +213,8 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
 
         # Add packages that were not grouped.
         packageGroups += [
-            rez_pip.pip.PackageGroup(tuple([package])) for package in packages
+            rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](tuple([package]))
+            for package in packages
         ]
 
         # TODO: Should we postpone downloading to the last minute if we can?

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -12,7 +12,6 @@ import tempfile
 import itertools
 import subprocess
 
-import rich
 import rich.text
 import rich.panel
 import rich.table
@@ -24,6 +23,7 @@ import rez_pip.pip
 import rez_pip.rez
 import rez_pip.data
 import rez_pip.patch
+import rez_pip.utils
 import rez_pip.plugins
 import rez_pip.install
 import rez_pip.download
@@ -193,7 +193,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
         installedWheelsDir = os.path.join(pipWorkArea, "installed", pythonVersion)
         os.makedirs(installedWheelsDir, exist_ok=True)
 
-        with rich.get_console().status(
+        with rez_pip.utils.CONSOLE.status(
             f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(args.packages))} (python-{pythonVersion})"
         ):
             packages = rez_pip.pip.getPackages(
@@ -247,7 +247,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
             f"[bold]Downloaded {downloaded} wheels, skipped {foundLocally} because they resolved to local files"
         )
 
-        with rich.get_console().status(
+        with rez_pip.utils.CONSOLE.status(
             f"[bold]Installing wheels into {installedWheelsDir!r}"
         ):
             for group in packageGroups:
@@ -264,7 +264,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
 
                     group.dists.append(dist)
 
-        with rich.get_console().status("[bold]Creating rez packages..."):
+        with rez_pip.utils.CONSOLE.status("[bold]Creating rez packages..."):
             for group in packageGroups:
                 rez_pip.rez.createPackage(
                     group,
@@ -276,7 +276,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
 
 
 def _debug(
-    args: argparse.Namespace, console: rich.console.Console = rich.get_console()
+    args: argparse.Namespace, console: rich.console.Console = rez_pip.utils.CONSOLE
 ) -> None:
     """Print debug information"""
     prefix = "  "
@@ -354,7 +354,7 @@ def _printPlugins() -> None:
     table = rich.table.Table("Name", "Hooks", box=None)
     for plugin, hooks in rez_pip.plugins._getHookImplementations().items():
         table.add_row(plugin, ", ".join(hooks))
-    rich.get_console().print(table)
+    rez_pip.utils.CONSOLE.print(table)
 
 
 def run() -> int:
@@ -387,7 +387,7 @@ def run() -> int:
         _run(args, pipArgs, pipWorkArea)
         return 0
     except rez_pip.exceptions.RezPipError as exc:
-        rich.get_console().print(exc, soft_wrap=True)
+        rez_pip.utils.CONSOLE.print(exc, soft_wrap=True)
         return 1
     finally:
         if not args.keep_tmp_dirs:

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -254,10 +254,9 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
             for group in packageGroups:
                 print(list(package.name for package in group.packages))
                 rez_pip.rez.createPackage(
-                    group.dists,
+                    group,
                     rez.version.Version(pythonVersion),
                     installedWheelsDir,
-                    group.downloadUrls,
                     prefix=args.prefix,
                     release=args.release,
                 )

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -23,6 +23,7 @@ import rich.logging
 import rez_pip.pip
 import rez_pip.rez
 import rez_pip.data
+import rez_pip.patch
 import rez_pip.plugins
 import rez_pip.install
 import rez_pip.download
@@ -251,12 +252,16 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
         ):
             for group in packageGroups:
                 for package in group.packages:
-                    _LOG.info(f"[bold]Installing {package.name} {package.path}")
+                    _LOG.info(f"[bold]Installing {package.name!r} {package.path!r}")
+                    targetPath = os.path.join(installedWheelsDir, package.name)
                     dist = rez_pip.install.installWheel(
                         package,
                         package.path,
-                        os.path.join(installedWheelsDir, package.name),
+                        targetPath,
                     )
+
+                    rez_pip.patch.patch(dist, targetPath)
+
                     group.dists.append(dist)
 
         with rich.get_console().status("[bold]Creating rez packages..."):

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -206,15 +206,17 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
             )
 
         _LOG.info(f"Resolved {len(packages)} dependencies for python {pythonVersion}")
-        packageGroups: typing.List[rez_pip.pip.PackageGroup] = list(
+        _packageGroups: typing.List[
+            rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo]
+        ] = list(
             itertools.chain(*rez_pip.plugins.getHook().groupPackages(packages=packages))  # type: ignore[arg-type]
         )
 
         # Remove empty groups
-        packageGroups = [group for group in packageGroups if group]
+        _packageGroups = [group for group in _packageGroups if group]
 
         # Add packages that were not grouped.
-        packageGroups += [
+        _packageGroups += [
             rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](tuple([package]))
             for package in packages
         ]
@@ -224,7 +226,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
 
         packageGroups: typing.List[
             rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]
-        ] = rez_pip.download.downloadPackages(packageGroups, wheelsDir)
+        ] = rez_pip.download.downloadPackages(_packageGroups, wheelsDir)
 
         foundLocally = downloaded = 0
         for group in packageGroups:

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -212,6 +212,12 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
             itertools.chain(*rez_pip.plugins.getHook().groupPackages(packages=packages))  # type: ignore[arg-type]
         )
 
+        # TODO: Verify that no packages are in two or more groups? It should theorically
+        # not be possible since plugins are called one after the other? But it could happen
+        # if a plugin forgets to pop items from the package list... The problem is that we
+        # can't know which plugin did what, so we could only say "something went wrong"
+        # and can't point to which plugin is at fault.
+
         # Remove empty groups
         _packageGroups = [group for group in _packageGroups if group]
 

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -10,11 +10,6 @@ import tempfile
 import itertools
 import subprocess
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import rich
 import rich.text
 import rich.panel
@@ -30,6 +25,7 @@ import rez_pip.plugins
 import rez_pip.install
 import rez_pip.download
 import rez_pip.exceptions
+from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger("rez_pip.cli")
 

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -260,6 +260,7 @@ def _run(args: argparse.Namespace, pipArgs: typing.List[str], pipWorkArea: str) 
                         targetPath,
                     )
 
+                    rez_pip.install.cleanup(dist, targetPath)
                     rez_pip.patch.patch(dist, targetPath)
 
                     group.dists.append(dist)

--- a/src/rez_pip/compat.py
+++ b/src/rez_pip/compat.py
@@ -1,0 +1,13 @@
+import sys
+
+if sys.version_info <= (3, 8):
+    from typing import Sequence, MutableSequence, Mapping
+else:
+    from collections.abc import Sequence, MutableSequence, Mapping
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+__all__ = ["Sequence", "MutableSequence", "Mapping", "importlib_metadata"]

--- a/src/rez_pip/data/patches/pyside6_6_0_0_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_0_0_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-11 15:01:54.266726602 -0500
++++ python/PySide6/__init__.py	2025-01-11 15:06:19.646365323 -0500
+@@ -10,14 +10,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = os.path.dirname(package_dir)
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.endswith('.zip'):
+-        return []
+-    shiboken6 = os.path.join(root, 'shiboken6')
+-    if os.path.isdir(shiboken6): # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = os.path.join(os.path.dirname(root), 'shiboken6', 'libshiboken')

--- a/src/rez_pip/data/patches/pyside6_6_1_0_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_1_0_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-11 14:43:26.190668073 -0500
++++ python/PySide6/__init__.py	2025-01-11 15:09:43.741718533 -0500
+@@ -11,14 +11,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = Path(package_dir).parent
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.suffix == '.zip':
+-        return []
+-    shiboken6 = root / 'shiboken6'
+-    if shiboken6.is_dir(): # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = Path(root).parent / 'shiboken6' / 'libshiboken'

--- a/src/rez_pip/data/patches/pyside6_6_2_4_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_2_4_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-11 14:43:29.390687962 -0500
++++ python/PySide6/__init__.py	2025-01-11 15:11:41.569480197 -0500
+@@ -11,14 +11,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = Path(package_dir).parent
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.suffix == '.zip':
+-        return []
+-    shiboken6 = root / 'shiboken6'
+-    if shiboken6.is_dir(): # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = Path(root).parent / 'shiboken6' / 'libshiboken'

--- a/src/rez_pip/data/patches/pyside6_6_3_0_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_3_0_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-11 14:43:29.554022310 -0500
++++ python/PySide6/__init__.py	2025-01-11 15:13:40.307210955 -0500
+@@ -12,14 +12,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = Path(package_dir).parent
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.suffix == '.zip':
+-        return []
+-    shiboken6 = root / 'shiboken6'
+-    if shiboken6.is_dir(): # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = Path(root).parent / 'shiboken6' / 'libshiboken'

--- a/src/rez_pip/data/patches/pyside6_6_7_3_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_7_3_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-12 11:37:31.807822271 -0500
++++ python/PySide6/__init__.py	2025-01-12 11:46:10.322763362 -0500
+@@ -10,14 +10,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = Path(package_dir).parent
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.suffix == '.zip':
+-        return []
+-    shiboken6 = root / 'shiboken6'
+-    if shiboken6.is_dir(): # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = Path(root).parent / 'shiboken6' / 'libshiboken'

--- a/src/rez_pip/data/patches/pyside6_6_8_1_win_dll_path.patch
+++ b/src/rez_pip/data/patches/pyside6_6_8_1_win_dll_path.patch
@@ -1,0 +1,20 @@
+--- python/PySide6/__init__.py	2025-01-12 11:53:31.681352613 -0500
++++ python/PySide6/__init__.py	2025-01-12 11:56:58.385665284 -0500
+@@ -13,14 +13,9 @@
+ 
+ 
+ def _additional_dll_directories(package_dir):
+-    # Find shiboken6 relative to the package directory.
+-    root = Path(package_dir).parent
+-    # Check for a flat .zip as deployed by cx_free(PYSIDE-1257)
+-    if root.suffix == '.zip':
+-        return []
+-    shiboken6 = root / 'shiboken6'
+-    if shiboken6.is_dir():  # Standard case, only shiboken6 is needed
+-        return [shiboken6]
++    # rez-pip patch: Return the path to the shiboken rez package
++    return [os.path.join(os.environ["REZ_SHIBOKEN6_ROOT"], "python", "shiboken6")]
++
+     # The below code is for the build process when generate_pyi.py
+     # is executed in the build directory. We need libpyside and Qt in addition.
+     shiboken6 = Path(root).parent / 'shiboken6' / 'libshiboken'

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -6,11 +6,11 @@ import asyncio
 import hashlib
 import logging
 
-import rich
 import aiohttp
 import rich.progress
 
 import rez_pip.pip
+import rez_pip.utils
 from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ async def _downloadPackages(
             rich.progress.DownloadColumn(),
             rich.progress.TransferSpeedColumn(),
             transient=True,
-            console=rich.get_console(),
+            console=rez_pip.utils.CONSOLE,
         ) as progress:
             tasks: typing.Dict[str, rich.progress.TaskID] = {}
 

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import typing
 import asyncio
 import hashlib
@@ -9,12 +8,8 @@ import rich
 import aiohttp
 import rich.progress
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import rez_pip.pip
+from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 _lock = asyncio.Lock()

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -83,12 +83,16 @@ async def _downloadPackages(
 
                     if not package.isDownloadRequired():
 
-                        async def _return_local() -> rez_pip.pip.DownloadedArtifact:
+                        # Note the subtlety of having to pass variables in the function
+                        # signature. We can't rely on the scoped variable.
+                        async def _return_local(
+                            _wheelPath: str, _package: rez_pip.pip.PackageInfo
+                        ) -> rez_pip.pip.DownloadedArtifact:
                             return rez_pip.pip.DownloadedArtifact.from_dict(
-                                {"_localPath": wheelPath, **package.to_dict()}
+                                {"_localPath": _wheelPath, **_package.to_dict()}
                             )
 
-                        futures.append(_return_local())
+                        futures.append(_return_local(wheelPath, package))
                     else:
                         futures.append(
                             _download(

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -81,7 +81,7 @@ async def _downloadPackages(
 
                     if not package.isDownloadRequired():
 
-                        async def _return_local():
+                        async def _return_local() -> rez_pip.pip.DownloadedArtifact:
                             return rez_pip.pip.DownloadedArtifact.from_dict(
                                 {"_localPath": wheelPath, **package.to_dict()}
                             )

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing
 import asyncio
@@ -93,7 +95,7 @@ async def _downloadPackages(
                                 package,
                                 session,
                                 progress,
-                                tasks.get(package.name, None),
+                                tasks[package.name],
                                 mainTask,
                                 wheelName,
                                 wheelPath,
@@ -141,7 +143,7 @@ async def _download(
     package: rez_pip.pip.PackageInfo,
     session: aiohttp.ClientSession,
     progress: rich.progress.Progress,
-    taskID: rich.progress.TaskID | None,
+    taskID: rich.progress.TaskID,
     mainTaskID: rich.progress.TaskID,
     wheelName: str,
     wheelPath: str,

--- a/src/rez_pip/exceptions.py
+++ b/src/rez_pip/exceptions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import rich
 import rich.console
 

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -41,7 +41,9 @@ def isWheelPure(dist: importlib_metadata.Distribution) -> bool:
     assert dist.files is not None
 
     path = next(
-        f for f in dist.files if os.fspath(f.locate()).endswith(".dist-info/WHEEL")
+        f
+        for f in dist.files
+        if os.fspath(f.locate()).endswith(os.path.join(".dist-info", "WHEEL"))
     )
     with open(path.locate()) as fd:
         metadata = installer.utils.parse_metadata_file(fd.read())

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -296,6 +296,8 @@ def deleteEntryFromRecord(
     with open(recordFilePath, "r") as f:
         lines = f.readlines()
 
+    print("Lines in RECORD:", lines)
+
     schemesRaw = getSchemeDict(dist.name, path)
     schemes = {
         key: os.path.relpath(value, path)
@@ -309,6 +311,7 @@ def deleteEntryFromRecord(
     for index, entry in enumerate(entries):
         for schemePath in schemes.values():
             if entry.startswith(schemePath):
+                _LOG.info(f"Stripping {schemePath!r}/ from {entry!r}")
                 entries[index] = entry.lstrip(schemePath + "/")
                 # Break on first match
                 break

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -264,7 +264,9 @@ def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
 
             print(path)
             print(action.path)
-            recordEntriesToRemove.append(os.path.relpath(action.path, path))
+            recordEntriesToRemove.append(
+                os.path.normpath(os.path.relpath(action.path, path)).replace("\\", "/")
+            )
         else:
             raise CleanupError(f"Unknown action: {action.op}")
 

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -2,6 +2,8 @@
 Code that takes care of installing (extracting) wheels.
 """
 
+from __future__ import annotations
+
 import io
 import os
 import sys

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -243,7 +243,6 @@ def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
 
     recordEntriesToRemove = []
 
-    _LOG.info(actions)
     for action in actions:
         if not action.path.startswith(path):
             # Security measure. Only perform operations on
@@ -262,8 +261,6 @@ def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
             else:
                 os.remove(action.path)
 
-            print(path)
-            print(action.path)
             recordEntriesToRemove.append(
                 os.path.normpath(os.path.relpath(action.path, path)).replace("\\", "/")
             )
@@ -298,8 +295,6 @@ def deleteEntryFromRecord(
     with open(recordFilePath, "r") as f:
         lines = f.readlines()
 
-    print("Lines in RECORD:", lines)
-
     schemesRaw = getSchemeDict(dist.name, path)
     schemes = {
         key: os.path.relpath(value, path)
@@ -313,7 +308,7 @@ def deleteEntryFromRecord(
     for index, entry in enumerate(entries):
         for schemePath in schemes.values():
             if entry.startswith(schemePath):
-                _LOG.info(f"Stripping {schemePath!r}/ from {entry!r}")
+                _LOG.debug(f"Stripping {schemePath!r}/ from {entry!r}")
                 entries[index] = entry.lstrip(schemePath + "/")
                 # Break on first match
                 break

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -11,11 +11,6 @@ import logging
 import pathlib
 import sysconfig
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 if typing.TYPE_CHECKING:
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -30,6 +25,7 @@ import installer.sources
 import installer.destinations
 
 import rez_pip.pip
+from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/rez_pip/install.py
+++ b/src/rez_pip/install.py
@@ -39,6 +39,9 @@ if typing.TYPE_CHECKING:
 
 
 def isWheelPure(dist: importlib_metadata.Distribution) -> bool:
+    # dist.files should never be empty, but assert to silence mypy.
+    assert dist.files is not None
+
     path = next(
         f for f in dist.files if os.fspath(f.locate()).endswith(".dist-info/WHEEL")
     )
@@ -72,7 +75,7 @@ def getSchemeDict(name: str, target: str) -> typing.Dict[str, str]:
 
 def installWheel(
     package: rez_pip.pip.PackageInfo,
-    wheelPath: pathlib.Path,
+    wheelPath: str,
     targetPath: str,
 ) -> importlib_metadata.Distribution:
     # TODO: Technically, target should be optional. We will always want to install in "pip install --target"
@@ -86,7 +89,7 @@ def installWheel(
     )
 
     _LOG.debug(f"Installing {wheelPath} into {targetPath!r}")
-    with installer.sources.WheelFile.open(wheelPath) as source:
+    with installer.sources.WheelFile.open(pathlib.Path(wheelPath)) as source:
         installer.install(
             source=source,
             destination=destination,

--- a/src/rez_pip/patch.py
+++ b/src/rez_pip/patch.py
@@ -1,0 +1,51 @@
+import os
+import typing
+import logging
+
+import patch_ng
+
+import rez_pip.data.patches
+import rez_pip.plugins
+import rez_pip.exceptions
+from rez_pip.compat import importlib_metadata
+
+_LOG = logging.getLogger(__name__)
+
+
+class PatchError(rez_pip.exceptions.RezPipError):
+    pass
+
+
+def getBuiltinPatchesDir() -> str:
+    """Get the built-in patches directory"""
+    return os.path.dirname(rez_pip.data.patches.__file__)
+
+
+def patch(dist: importlib_metadata.Distribution, path: str):
+    """Patch an installed package (wheel)"""
+    _LOG.debug(f"[bold]Attempting to patch {dist.name!r} at {path!r}")
+    patchesGroups: typing.List[list[str]] = rez_pip.plugins.getHook().patches(
+        dist=dist, path=path
+    )
+
+    # Flatten the list
+    patches = [path for group in patchesGroups for path in group]
+
+    if not patches:
+        _LOG.debug(f"No patches found")
+        return
+
+    _LOG.info(f"Applying {len(patches)} patches for {dist.name!r} at {path!r}")
+
+    for patch in patches:
+        _LOG.info(f"Applying patch {patch!r} on {path!r}")
+
+        if not os.path.isabs(patch):
+            raise PatchError(f"{patch!r} is not an absolute path")
+
+        if not os.path.exists(patch):
+            raise PatchError(f"Patch at {patch!r} does not exist")
+
+        patchset = patch_ng.fromfile(patch)
+        if not patchset.apply(root=path):
+            raise PatchError(f"Failed to apply patch {patch!r} on {path!r}")

--- a/src/rez_pip/patch.py
+++ b/src/rez_pip/patch.py
@@ -47,5 +47,5 @@ def patch(dist: importlib_metadata.Distribution, path: str):
             raise PatchError(f"Patch at {patch!r} does not exist")
 
         patchset = patch_ng.fromfile(patch)
-        if not patchset.apply(root=path, fuzz=True):
+        if not patchset.apply(root=path):
             raise PatchError(f"Failed to apply patch {patch!r} on {path!r}")

--- a/src/rez_pip/patch.py
+++ b/src/rez_pip/patch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing
 import logging
@@ -5,6 +7,7 @@ import logging
 import patch_ng
 
 import rez_pip.data.patches
+import rez_pip.compat
 import rez_pip.plugins
 import rez_pip.exceptions
 from rez_pip.compat import importlib_metadata
@@ -21,11 +24,11 @@ def getBuiltinPatchesDir() -> str:
     return os.path.dirname(rez_pip.data.patches.__file__)
 
 
-def patch(dist: importlib_metadata.Distribution, path: str):
+def patch(dist: importlib_metadata.Distribution, path: str) -> None:
     """Patch an installed package (wheel)"""
     _LOG.debug(f"[bold]Attempting to patch {dist.name!r} at {path!r}")
-    patchesGroups: typing.List[list[str]] = rez_pip.plugins.getHook().patches(
-        dist=dist, path=path
+    patchesGroups: rez_pip.compat.Sequence[rez_pip.compat.Sequence[str]] = (
+        rez_pip.plugins.getHook().patches(dist=dist, path=path)
     )
 
     # Flatten the list

--- a/src/rez_pip/patch.py
+++ b/src/rez_pip/patch.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import os
+import math
 import typing
 import logging
+import contextlib
+import logging.handlers
 
 import patch_ng
 
-import rez_pip.data.patches
+import rez_pip.utils
 import rez_pip.compat
 import rez_pip.plugins
 import rez_pip.exceptions
+import rez_pip.data.patches
 from rez_pip.compat import importlib_metadata
+
 
 _LOG = logging.getLogger(__name__)
 
@@ -22,6 +27,40 @@ class PatchError(rez_pip.exceptions.RezPipError):
 def getBuiltinPatchesDir() -> str:
     """Get the built-in patches directory"""
     return os.path.dirname(rez_pip.data.patches.__file__)
+
+
+@contextlib.contextmanager
+def logIfErrorOrRaises() -> typing.Generator[None]:
+    """
+    Log patch_ng logs if any error is logged or if the wrapped body raises.
+    Very slightly inspired by https://docs.python.org/3/howto/logging-cookbook.html#buffering-logging-messages-and-outputting-them-conditionally
+
+    We basically don't want any logs from patch_ng is everything worked. We only
+    want logs when something wrong happens.
+    """
+    patch_ng.debugmode = True
+    logger = logging.getLogger("patch_ng")
+    initialLevel = logger.level
+    logger.setLevel(logging.DEBUG)
+
+    handler = logging.handlers.MemoryHandler(
+        math.inf,  # type: ignore[arg-type]
+        flushLevel=logging.ERROR,
+        target=logging.getLogger("rez_pip").handlers[0],
+    )
+    handler.setFormatter(logging.Formatter("%(name)s %(levelname)8s %(message)s"))
+
+    logger.addHandler(handler)
+
+    try:
+        yield
+    except Exception as exc:
+        handler.flush()
+        raise exc from None
+    finally:
+        patch_ng.debugmode = False
+        logger.setLevel(initialLevel)
+        logger.removeHandler(handler)
 
 
 def patch(dist: importlib_metadata.Distribution, path: str) -> None:
@@ -50,5 +89,7 @@ def patch(dist: importlib_metadata.Distribution, path: str) -> None:
             raise PatchError(f"Patch at {patch!r} does not exist")
 
         patchset = patch_ng.fromfile(patch)
-        if not patchset.apply(root=path):
-            raise PatchError(f"Failed to apply patch {patch!r} on {path!r}")
+        with logIfErrorOrRaises():
+            if not patchset.apply(root=path):
+                # A logger that only gets flushed on demand would be better...
+                raise PatchError(f"Failed to apply patch {patch!r} on {path!r}")

--- a/src/rez_pip/patch.py
+++ b/src/rez_pip/patch.py
@@ -47,5 +47,5 @@ def patch(dist: importlib_metadata.Distribution, path: str):
             raise PatchError(f"Patch at {patch!r} does not exist")
 
         patchset = patch_ng.fromfile(patch)
-        if not patchset.apply(root=path):
+        if not patchset.apply(root=path, fuzz=True):
             raise PatchError(f"Failed to apply patch {patch!r} on {path!r}")

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -8,16 +8,14 @@ import itertools
 import subprocess
 import dataclasses
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import dataclasses_json
 
 import rez_pip.data
 import rez_pip.plugins
 import rez_pip.exceptions
+
+if typing.TYPE_CHECKING:
+    import importlib.metadata as importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -134,6 +134,13 @@ class PackageGroup(typing.Generic[T]):
     def __bool__(self) -> bool:
         return bool(self.packages)
 
+    def __eq__(self, value: typing.Any) -> bool:
+        """Needed for tests"""
+        if not isinstance(value, PackageGroup):
+            return False
+
+        return self.packages == value.packages and self.dists == value.dists
+
     @property
     def downloadUrls(self) -> typing.List[str]:
         """List of download URLs"""

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -115,11 +115,12 @@ class PackageGroup(typing.Generic[T]):
     packages: typing.Tuple[T, ...]
 
     #: List of distributions
-    dists: typing.List[rez_pip.compat.importlib_metadata.Distribution] = []
+    dists: typing.List[rez_pip.compat.importlib_metadata.Distribution]
 
     # Using a tuple to make it immutable
     def __init__(self, packages: typing.Tuple[T, ...]) -> None:
         self.packages = packages
+        self.dists = []
 
     def __str__(self) -> str:
         return "PackageGroup({})".format(

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -93,8 +93,8 @@ class PackageGroup(typing.Generic[T]):
     """A group of package"""
 
     # Using a tuple to make it immutable
-    def __init__(self, packages: typing.Tuple[T]) -> None:
-        self.packages: typing.Tuple[T] = packages
+    def __init__(self, packages: typing.Tuple[T, ...]) -> None:
+        self.packages: typing.Tuple[T, ...] = packages
         self.dists: typing.List["importlib_metadata.Distribution"] = []
 
     def __str__(self) -> str:

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -128,9 +128,7 @@ def getPackages(
     constraints: typing.List[str],
     extraArgs: typing.List[str],
 ) -> typing.List[PackageInfo]:
-    rez_pip.plugins.getHook().prePipResolve(
-        packages=packageNames, requirements=requirements
-    )
+    rez_pip.plugins.getHook().prePipResolve(tuple(packageNames), tuple(requirements))
 
     _fd, tmpFile = tempfile.mkstemp(prefix="pip-install-output", text=True)
     os.close(_fd)
@@ -197,7 +195,7 @@ def getPackages(
         packageInfo = PackageInfo.from_dict(rawPackage)
         packages.append(packageInfo)
 
-    rez_pip.plugins.getHook().postPipResolve(packages=packages)
+    rez_pip.plugins.getHook().postPipResolve(tuple(packages))
 
     return packages
 

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -24,19 +24,27 @@ _LOG = logging.getLogger(__name__)
 
 @dataclasses.dataclass
 class Metadata(dataclasses_json.DataClassJsonMixin):
+    """Represents metadata for a package"""
+
     version: str
     name: str
 
 
 @dataclasses.dataclass
 class ArchiveInfo(dataclasses_json.DataClassJsonMixin):
+    #: Archive hash
     hash: str
+
+    #: Archive hashes
     hashes: typing.Dict[str, str]
 
 
 @dataclasses.dataclass
 class DownloadInfo(dataclasses_json.DataClassJsonMixin):
+    #: Download URL
     url: str
+
+    #: Archive information
     archive_info: ArchiveInfo
 
     dataclass_json_config = dataclasses_json.config(
@@ -46,9 +54,18 @@ class DownloadInfo(dataclasses_json.DataClassJsonMixin):
 
 @dataclasses.dataclass(frozen=True)
 class PackageInfo(dataclasses_json.DataClassJsonMixin):
+    """Represents data returned by pip for a single package"""
+
+    #: Download information
     download_info: DownloadInfo
+
+    #: Is this a direct dependency?
     is_direct: bool
+
+    #: Is this a requested package?
     requested: bool
+
+    #: Metadata about the package
     metadata: Metadata
 
     dataclass_json_config = dataclasses_json.config(
@@ -57,10 +74,12 @@ class PackageInfo(dataclasses_json.DataClassJsonMixin):
 
     @property
     def name(self) -> str:
+        """Package name"""
         return self.metadata.name
 
     @property
     def version(self) -> str:
+        """Package version"""
         return self.metadata.version
 
     def isDownloadRequired(self) -> bool:
@@ -70,7 +89,7 @@ class PackageInfo(dataclasses_json.DataClassJsonMixin):
 @dataclasses.dataclass(frozen=True)  # Nonsense, but we have to do this here too...
 class DownloadedArtifact(PackageInfo):
     """
-    This is a subclass of PackageInfo. It's used to represent a local wheel.
+    This is a subclass of :class:`PackageInfo`. It's used to represent a local wheel.
     It is immutable so that we can clearly express immutability in plugins.
     """
 
@@ -90,8 +109,12 @@ T = typing.TypeVar("T", PackageInfo, DownloadedArtifact)
 
 
 class PackageGroup(typing.Generic[T]):
-    """A group of package"""
+    """A group of package. The order of packages and dists must be the same."""
+
+    #: List of packages
     packages: typing.Tuple[T, ...]
+
+    #: List of distributions
     dists: typing.List[rez_pip.compat.importlib_metadata.Distribution] = []
 
     # Using a tuple to make it immutable
@@ -113,6 +136,7 @@ class PackageGroup(typing.Generic[T]):
 
     @property
     def downloadUrls(self) -> typing.List[str]:
+        """List of download URLs"""
         return [p.download_info.url for p in self.packages]
 
 

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -67,7 +67,7 @@ class PackageInfo(dataclasses_json.DataClassJsonMixin):
     def version(self) -> str:
         return self.metadata.version
 
-    def isDownloadRequired(self):
+    def isDownloadRequired(self) -> bool:
         return not self.download_info.url.startswith("file://")
 
     @property

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -89,7 +89,7 @@ class PackageGroup:
     """A group of package"""
 
     packages: typing.List[PackageInfo]
-    dists: typing.List[importlib_metadata.Distribution]
+    dists: typing.List["importlib_metadata.Distribution"]
 
     def __init__(self, packages: typing.List[PackageInfo]) -> None:
         self.packages = packages

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -13,14 +13,8 @@ So it's at least a 3 steps process:
 """
 
 import os
-import sys
 import shutil
 import typing
-
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 import packaging.utils
 import packaging.version
@@ -30,6 +24,9 @@ import packaging.requirements
 import rez_pip.pip
 import rez_pip.plugins
 import rez_pip.exceptions
+
+if typing.TYPE_CHECKING:
+    from rez_pip.compat import importlib_metadata
 
 # PySide6 was initiall a single package that had shiboken as a dependency.
 # Starting from 6.3.0, the package was spit in 3, PySide6, PySide6-Essentials and

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -101,7 +101,7 @@ def groupPackages(
 
 
 @rez_pip.plugins.hookimpl
-def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
+def cleanup(dist: "importlib_metadata.Distribution", path: str) -> None:
     if packaging.utils.canonicalize_name(dist.name) not in [
         "pyside6",
         "pyside6-addons",

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -12,6 +12,8 @@ So it's at least a 3 steps process:
 2. Install shiboken + cleanup. The Cleanup could be its own hook here specific to shiboken.
 """
 
+from __future__ import annotations
+
 import os
 import shutil
 import typing
@@ -98,12 +100,7 @@ def groupPackages(
             data.append(package)
             packages.remove(package)
 
-    return [
-        rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](
-            # Casting to get rid of ... in tuple[type, ...]
-            typing.cast(typing.Tuple[rez_pip.pip.PackageInfo], tuple(data))
-        )
-    ]
+    return [rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](tuple(data))]
 
 
 @rez_pip.plugins.hookimpl

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -1,0 +1,120 @@
+"""PySide6 plugin.
+
+For PySide6, we need a merge hook. If User says "install PySide6", we need to install PySide6, PySide6-Addons and PySide6-Essentials and shiboken6.
+
+But PySide6, PySide6-Addons and PySide6-Essentials have to be merged. Additionally, shiboken6 needs to be broken down to remove PySide6 (core).
+Because shiboken6 vendors PySide6-core... See https://inspector.pypi.io/project/shiboken6/6.6.1/packages/bb/72/e54f758e49e8da0dcd9490d006c41a814b0e56898ce4ca054d60cdba97bd/shiboken6-6.6.1-cp38-abi3-manylinux_2_28_x86_64.whl/.
+
+On Windows, the PySide6/openssl folder has to be added to PATH, see https://inspector.pypi.io/project/pyside6/6.6.1/packages/ec/3d/1da1b88d74cb5318466156bac91f17ad4272c6c83a973e107ad9a9085009/PySide6-6.6.1-cp38-abi3-win_amd64.whl/PySide6/__init__.py#line.81.
+
+So it's at least a 3 steps process:
+1. Merge PySide6, PySide6-Essentials and PySide6-Addons into the same install. Unvendor shiboken.
+2. Install shiboken + cleanup. The Cleanup could be its own hook here specific to shiboken.
+"""
+import os
+import sys
+import shutil
+import typing
+import logging
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+import packaging.utils
+import packaging.version
+import packaging.specifiers
+import packaging.requirements
+
+import rez_pip.pip
+import rez_pip.plugins
+import rez_pip.exceptions
+
+# PySide6 was initiall a single package that had shiboken as a dependency.
+# Starting from 6.3.0, the package was spit in 3, PySide6, PySide6-Essentials and
+# PySide6-Addons.
+
+
+_LOG = logging.getLogger(__name__)
+
+
+@rez_pip.plugins.hookimpl
+def prePipResolve(
+    packages: typing.List[str],
+) -> None:
+    _LOG.debug(f"prePipResolve start")
+    pyside6Seen = False
+    variantsSeens = []
+
+    for package in packages:
+        req = packaging.requirements.Requirement(package)
+        name = packaging.utils.canonicalize_name(req.name)
+
+        if name == "pyside6":
+            pyside6Seen = True
+        elif name in ["pyside6-essentials", "pyside6-addons"]:
+            variantsSeens.append(req.name)
+
+    if variantsSeens and not pyside6Seen:
+        variants = " and ".join(variantsSeens)
+        verb = "was" if len(variantsSeens) == 1 else "were"
+        raise rez_pip.exceptions.RezPipError(
+            f"{variants} {verb} requested but PySide6 was not. You must explicitly request PySide6 in addition to {variants}."
+        )
+
+
+@rez_pip.plugins.hookimpl
+def postPipResolve(packages: typing.List[rez_pip.pip.PackageInfo]) -> None:
+    """
+    This hook is implemented out of extra caution. We really don't want PySide6-Addons
+    or PySide6-Essentials to be installed without PySide6.
+
+    In this case, we cover cases where a user requests a package X and that package
+    depends on PySide6-Addons or PySide6-Essentials.
+    """
+    pyside6Seen = False
+    variantsSeens = []
+
+    for package in packages:
+        name = packaging.utils.canonicalize_name(package.name)
+        if name == "pyside6":
+            pyside6Seen = True
+        elif name in ["pyside6-essentials", "pyside6-addons"]:
+            variantsSeens.append(package.name)
+
+    if variantsSeens and not pyside6Seen:
+        variants = " and ".join(variantsSeens)
+        verb = "is" if len(variantsSeens) == 1 else "are"
+        raise rez_pip.exceptions.RezPipError(
+            f"{variants} {verb} part of the resolved packages but PySide6 was not. Dependencies and or you must explicitly request PySide6 in addition to {variants}."
+        )
+
+
+@rez_pip.plugins.hookimpl
+def groupPackages(
+    packages: typing.List[rez_pip.pip.PackageInfo],
+) -> typing.List[rez_pip.pip.PackageGroup]:
+    data = []
+    for index, package in enumerate(packages[:]):
+        if packaging.utils.canonicalize_name(package.name) in [
+            "pyside6",
+            "pyside6-addons",
+            "pyside6-essentials",
+        ]:
+            data.append(package)
+            packages.remove(package)
+    return [rez_pip.pip.PackageGroup(data)]
+
+
+@rez_pip.plugins.hookimpl
+def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
+    if packaging.utils.canonicalize_name(dist.name) not in [
+        "pyside6",
+        "pyside6-addons",
+        "pyside6-essentials",
+    ]:
+        return
+
+    shutil.rmtree(os.path.join(path, "python", "shiboken6"))
+    shutil.rmtree(os.path.join(path, "python", "shiboken6_generator"))

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -87,7 +87,7 @@ def postPipResolve(packages: typing.List[rez_pip.pip.PackageInfo]) -> None:
 @rez_pip.plugins.hookimpl
 def groupPackages(
     packages: typing.List[rez_pip.pip.PackageInfo],
-) -> typing.List[rez_pip.pip.PackageGroup]:
+) -> typing.List[rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo]]:
     data = []
     for index, package in enumerate(packages[:]):
         if packaging.utils.canonicalize_name(package.name) in [
@@ -97,7 +97,13 @@ def groupPackages(
         ]:
             data.append(package)
             packages.remove(package)
-    return [rez_pip.pip.PackageGroup(data)]
+
+    return [
+        rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](
+            # Casting to get rid of ... in tuple[type, ...]
+            typing.cast(typing.Tuple[rez_pip.pip.PackageInfo], tuple(data))
+        )
+    ]
 
 
 @rez_pip.plugins.hookimpl

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -142,10 +142,23 @@ def patches(dist: "importlib_metadata.Distribution", path: str) -> typing.List[s
             )
         )
 
-    elif version in packaging.specifiers.SpecifierSet(">=6.3.0"):
+    elif version in packaging.specifiers.SpecifierSet(">=6.3.0,<6.7.3"):
         patches.append(
             os.path.join(
                 rez_pip.patch.getBuiltinPatchesDir(), "pyside6_6_3_0_win_dll_path.patch"
+            )
+        )
+
+    elif version in packaging.specifiers.SpecifierSet(">=6.7.3,<6.8.1"):
+        patches.append(
+            os.path.join(
+                rez_pip.patch.getBuiltinPatchesDir(), "pyside6_6_7_3_win_dll_path.patch"
+            )
+        )
+    elif version in packaging.specifiers.SpecifierSet(">=6.8.1"):
+        patches.append(
+            os.path.join(
+                rez_pip.patch.getBuiltinPatchesDir(), "pyside6_6_8_1_win_dll_path.patch"
             )
         )
     return patches

--- a/src/rez_pip/plugins/PySide6.py
+++ b/src/rez_pip/plugins/PySide6.py
@@ -11,11 +11,11 @@ So it's at least a 3 steps process:
 1. Merge PySide6, PySide6-Essentials and PySide6-Addons into the same install. Unvendor shiboken.
 2. Install shiboken + cleanup. The Cleanup could be its own hook here specific to shiboken.
 """
+
 import os
 import sys
 import shutil
 import typing
-import logging
 
 if sys.version_info >= (3, 10):
     import importlib.metadata as importlib_metadata
@@ -36,14 +36,10 @@ import rez_pip.exceptions
 # PySide6-Addons.
 
 
-_LOG = logging.getLogger(__name__)
-
-
 @rez_pip.plugins.hookimpl
 def prePipResolve(
     packages: typing.List[str],
 ) -> None:
-    _LOG.debug(f"prePipResolve start")
     pyside6Seen = False
     variantsSeens = []
 
@@ -116,5 +112,9 @@ def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
     ]:
         return
 
+    # Remove shiboken6 from PySide6 packages...
+    # PySide6 >=6.3, <6.6.2 were shipping some shiboken6 folders by mistake.
+    # Not removing these extra folders would stop python from being able to import
+    # the correct shiboken (that lives in a separate rez package).
     shutil.rmtree(os.path.join(path, "python", "shiboken6"))
     shutil.rmtree(os.path.join(path, "python", "shiboken6_generator"))

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -88,7 +88,8 @@ def getManager() -> pluggy.PluginManager:
     # Register the builtin plugins
     for module in pkgutil.iter_modules(__path__):
         manager.register(
-            importlib.import_module(f"rez_pip.plugins.{module.name}"), name=module.name
+            importlib.import_module(f"rez_pip.plugins.{module.name}"),
+            name=f"rez_pip.{module.name}",
         )
 
     manager.load_setuptools_entrypoints("rez-pip")

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -82,6 +82,20 @@ class PluginSpec:
         """
 
     @hookspec
+    def patches(
+        self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
+    ) -> typing.Sequence[str]:
+        """
+        Provide paths to patches to be applied on the source code of a package.
+
+        :param dist: Python distribution.
+        :param path: Root path of the installed content.
+        """
+        # TODO: This will alter files (obviously) and change their hashes.
+        # This could be a problem to verify the integrity of the package.
+        # https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-record-file
+
+    @hookspec
     def cleanup(
         self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
     ) -> None:

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -67,8 +67,10 @@ class PluginSpec:
     @hookspec
     def groupPackages(  # type: ignore[empty-body]
         self,
-        packages: 'rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]',
-    ) -> 'rez_pip.compat.Sequence["rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]"]':
+        packages: rez_pip.compat.MutableSequence[rez_pip.pip.PackageInfo],
+    ) -> rez_pip.compat.Sequence[
+        rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]
+    ]:
         """
         Merge packages into groups of packages. The name and version of the first package
         in the group will be used as the name and version for the rez package.
@@ -81,7 +83,7 @@ class PluginSpec:
 
     @hookspec
     def cleanup(
-        self, dist: "rez_pip.compat.importlib_metadata.Distribution", path: str
+        self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
     ) -> None:
         """
         Cleanup a package post-installation.
@@ -102,8 +104,8 @@ class PluginSpec:
 
 def before(
     hookName: str,
-    hookImpls: "rez_pip.compat.Sequence[pluggy.HookImpl]",
-    kwargs: "rez_pip.compat.Mapping[str, typing.Any]",
+    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
+    kwargs: rez_pip.compat.Mapping[str, typing.Any],
 ) -> None:
     """Function that will be called before each hook."""
     _LOG.debug("Calling the %r hooks", hookName)
@@ -112,8 +114,8 @@ def before(
 def after(
     outcome: pluggy.Result[typing.Any],
     hookName: str,
-    hookImpls: "rez_pip.compat.Sequence[pluggy.HookImpl]",
-    kwargs: "rez_pip.compat.Mapping[str, typing.Any]",
+    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
+    kwargs: rez_pip.compat.Mapping[str, typing.Any],
 ) -> None:
     """Function that will be called after each hook."""
     _LOG.debug("Called the %r hooks", hookName)

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -33,8 +33,8 @@ class PluginSpec:
     @hookspec
     def prePipResolve(
         self,
-        packages: rez_pip.compat.Sequence[str],  # Immutable
-        requirements: rez_pip.compat.Sequence[str],  # Immutable
+        packages: "rez_pip.compat.Sequence[str]",  # Immutable
+        requirements: "rez_pip.compat.Sequence[str]",  # Immutable
     ) -> None:
         """
         Take an action before resolving the packages using pip.
@@ -43,7 +43,8 @@ class PluginSpec:
 
     @hookspec
     def postPipResolve(
-        self, packages: rez_pip.compat.Sequence["rez_pip.pip.PackageInfo"]  # Immutable
+        self,
+        packages: 'rez_pip.compat.Sequence["rez_pip.pip.PackageInfo"]',  # Immutable
     ) -> None:
         """
         Take an action after resolving the packages using pip.
@@ -52,8 +53,8 @@ class PluginSpec:
 
     @hookspec
     def groupPackages(  # type: ignore[empty-body]
-        self, packages: rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]
-    ) -> rez_pip.compat.Sequence["rez_pip.pip.PackageGroup"]:
+        self, packages: 'rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]'
+    ) -> 'rez_pip.compat.Sequence["rez_pip.pip.PackageGroup"]':
         """
         Merge packages into groups of packages. The name and version of the first package
         in the group will be used as the name and version for the rez package.
@@ -63,7 +64,7 @@ class PluginSpec:
 
     @hookspec
     def cleanup(
-        self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
+        self, dist: "rez_pip.compat.importlib_metadata.Distribution", path: str
     ) -> None:
         """Cleanup installed distribution"""
 
@@ -77,8 +78,8 @@ class PluginSpec:
 
 def before(
     hookName: str,
-    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
-    kwargs: rez_pip.compat.Mapping[str, typing.Any],
+    hookImpls: "rez_pip.compat.Sequence[pluggy.HookImpl]",
+    kwargs: "rez_pip.compat.Mapping[str, typing.Any]",
 ) -> None:
     """Function that will be called before each hook."""
     _LOG.debug("Calling the %r hooks", hookName)
@@ -87,8 +88,8 @@ def before(
 def after(
     outcome: pluggy.Result[typing.Any],
     hookName: str,
-    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
-    kwargs: rez_pip.compat.Mapping[str, typing.Any],
+    hookImpls: "rez_pip.compat.Sequence[pluggy.HookImpl]",
+    kwargs: "rez_pip.compat.Mapping[str, typing.Any]",
 ) -> None:
     """Function that will be called after each hook."""
     _LOG.debug("Called the %r hooks", hookName)

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -1,23 +1,17 @@
 """Plugin system."""
 
-import sys
 import typing
 import logging
 import pkgutil
 import functools
 import importlib
-import collections.abc
-
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 import pluggy
 import rez.package_maker
 
 if typing.TYPE_CHECKING:
     import rez_pip.pip
+    import rez_pip.compat
 
 __all__ = [
     "hookimpl",
@@ -39,8 +33,8 @@ class PluginSpec:
     @hookspec
     def prePipResolve(
         self,
-        packages: collections.abc.Sequence[str],  # Immutable
-        requirements: collections.abc.Sequence[str],  # Immutable
+        packages: rez_pip.compat.Sequence[str],  # Immutable
+        requirements: rez_pip.compat.Sequence[str],  # Immutable
     ) -> None:
         """
         Take an action before resolving the packages using pip.
@@ -49,7 +43,7 @@ class PluginSpec:
 
     @hookspec
     def postPipResolve(
-        self, packages: collections.abc.Sequence["rez_pip.pip.PackageInfo"]  # Immutable
+        self, packages: rez_pip.compat.Sequence["rez_pip.pip.PackageInfo"]  # Immutable
     ) -> None:
         """
         Take an action after resolving the packages using pip.
@@ -58,8 +52,8 @@ class PluginSpec:
 
     @hookspec
     def groupPackages(  # type: ignore[empty-body]
-        self, packages: collections.abc.MutableSequence["rez_pip.pip.PackageInfo"]
-    ) -> collections.abc.Sequence["rez_pip.pip.PackageGroup"]:
+        self, packages: rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]
+    ) -> rez_pip.compat.Sequence["rez_pip.pip.PackageGroup"]:
         """
         Merge packages into groups of packages. The name and version of the first package
         in the group will be used as the name and version for the rez package.
@@ -68,7 +62,9 @@ class PluginSpec:
         """
 
     @hookspec
-    def cleanup(self, dist: importlib_metadata.Distribution, path: str) -> None:
+    def cleanup(
+        self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
+    ) -> None:
         """Cleanup installed distribution"""
 
     @hookspec
@@ -81,8 +77,8 @@ class PluginSpec:
 
 def before(
     hookName: str,
-    hookImpls: collections.abc.Sequence[pluggy.HookImpl],
-    kwargs: collections.abc.Mapping[str, typing.Any],
+    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
+    kwargs: rez_pip.compat.Mapping[str, typing.Any],
 ) -> None:
     """Function that will be called before each hook."""
     _LOG.debug("Calling the %r hooks", hookName)
@@ -91,8 +87,8 @@ def before(
 def after(
     outcome: pluggy.Result[typing.Any],
     hookName: str,
-    hookImpls: collections.abc.Sequence[pluggy.HookImpl],
-    kwargs: collections.abc.Mapping[str, typing.Any],
+    hookImpls: rez_pip.compat.Sequence[pluggy.HookImpl],
+    kwargs: rez_pip.compat.Mapping[str, typing.Any],
 ) -> None:
     """Function that will be called after each hook."""
     _LOG.debug("Called the %r hooks", hookName)

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -1,0 +1,118 @@
+"""Plugin system."""
+import sys
+import typing
+import logging
+import functools
+
+import pluggy
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+import rez.package_maker
+
+if typing.TYPE_CHECKING:
+    import rez_pip.pip
+
+__all__ = [
+    "hookimpl",
+]
+
+
+def __dir__() -> typing.List[str]:
+    return __all__
+
+
+__LOG = logging.getLogger(__name__)
+
+F = typing.TypeVar("F", bound=typing.Callable[..., typing.Any])
+hookspec = typing.cast(typing.Callable[[F], F], pluggy.HookspecMarker("rez-pip"))
+hookimpl = typing.cast(typing.Callable[[F], F], pluggy.HookimplMarker("rez-pip"))
+
+
+class PluginSpec:
+    @hookspec
+    def prePipResolve(
+        self, packages: typing.List[str], requirements: typing.List[str]
+    ) -> None:
+        """
+        Take an action before resolving the packages using pip.
+        The packages argument should not be modified in any way.
+        """
+
+    @hookspec
+    def postPipResolve(self, packages: typing.List["rez_pip.pip.PackageInfo"]) -> None:
+        """
+        Take an action after resolving the packages using pip.
+        The packages argument should not be modified in any way.
+        """
+
+    @hookspec
+    def groupPackages(  # type: ignore[empty-body]
+        self, packages: typing.List["rez_pip.pip.PackageInfo"]
+    ) -> typing.List["rez_pip.pip.PackageGroup"]:
+        """
+        Merge packages into groups of packages. The name and version of the first package
+        in the group will be used as the name and version for the rez package.
+
+        The hook must pop grouped packages out of the "packages" variable.
+        """
+
+    @hookspec
+    def cleanup(self, dist: importlib_metadata.Distribution, path: str) -> None:
+        """Cleanup installed distribution"""
+
+    @hookspec
+    def metadata(self, package: rez.package_maker.PackageMaker) -> None:
+        """
+        Modify/inject metadata in the rez package. The plugin is expected to modify
+        "package" in place.
+        """
+
+
+@functools.lru_cache()
+def getManager() -> pluggy.PluginManager:
+    """
+    Returns the plugin manager. The return value will be cached on first call
+    and the cached value will be return in subsequent calls.
+    """
+    import rez_pip.plugins.PySide6
+    import rez_pip.plugins.shiboken6
+
+    manager = pluggy.PluginManager("rez-pip")
+    # manager.trace.root.setwriter(print)
+    # manager.enable_tracing()
+
+    manager.add_hookspecs(PluginSpec)
+
+    manager.register(rez_pip.plugins.PySide6)
+    manager.register(rez_pip.plugins.shiboken6)
+
+    manager.load_setuptools_entrypoints("rez-pip")
+
+    # print(list(itertools.chain(*manager.hook.prePipResolve(packages=["asd"]))))
+    return manager
+
+
+def getHook() -> PluginSpec:
+    """
+    Returns the hook attribute from the manager. This is allows
+    to have type hints at the caller sites.
+
+    Inspired by https://stackoverflow.com/a/54695761.
+    """
+    manager = getManager()
+    return typing.cast(PluginSpec, manager.hook)
+
+
+def _getHookImplementations() -> typing.Dict[str, typing.List[str]]:
+    manager = getManager()
+
+    implementations = {}
+    for name, plugin in manager.list_name_plugin():
+        implementations[name] = [
+            caller.name for caller in manager.get_hookcallers(plugin)
+        ]
+    return implementations

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -98,7 +98,7 @@ class PluginSpec:
         Modify/inject metadata in the rez package. The plugin is expected to modify
         "package" in place.
 
-        :param package: An instanciate PackageMaker.
+        :param package: An insatnce of :class:`rez.package_maker.PackageMaker`.
         """
 
 

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -1,5 +1,7 @@
 """Plugin system."""
 
+from __future__ import annotations
+
 import typing
 import logging
 import pkgutil
@@ -33,8 +35,8 @@ class PluginSpec:
     @hookspec
     def prePipResolve(
         self,
-        packages: "rez_pip.compat.Sequence[str]",  # Immutable
-        requirements: "rez_pip.compat.Sequence[str]",  # Immutable
+        packages: typing.Tuple[str, ...],  # Immutable
+        requirements: typing.Tuple[str, ...],  # Immutable
     ) -> None:
         """
         The pre-pip resolve hook allows a plugin to run some checks *before* resolving the
@@ -50,7 +52,7 @@ class PluginSpec:
     @hookspec
     def postPipResolve(
         self,
-        packages: 'rez_pip.compat.Sequence["rez_pip.pip.PackageInfo"]',  # Immutable
+        packages: typing.Tuple[rez_pip.pip.PackageInfo, ...],  # Immutable
     ) -> None:
         """
         The post-pip resolve hook allows a plugin to run some checks *after* resolving the

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -37,8 +37,14 @@ class PluginSpec:
         requirements: "rez_pip.compat.Sequence[str]",  # Immutable
     ) -> None:
         """
-        Take an action before resolving the packages using pip.
-        The packages argument should not be modified in any way.
+        The pre-pip resolve hook allows a plugin to run some checks *before* resolving the
+        requested packages using pip. The hook **must** not modify the content of the
+        arguments passed to it.
+
+        Some use cases are allowing or disallowing the installation of some packages.
+
+        :param packages: List of packages requested by the user.
+        :param requirements: List of `requirements files <https://pip.pypa.io/en/stable/reference/requirements-file-format/#requirements-file-format>`_ if any.
         """
 
     @hookspec
@@ -47,32 +53,48 @@ class PluginSpec:
         packages: 'rez_pip.compat.Sequence["rez_pip.pip.PackageInfo"]',  # Immutable
     ) -> None:
         """
-        Take an action after resolving the packages using pip.
-        The packages argument should not be modified in any way.
+        The post-pip resolve hook allows a plugin to run some checks *after* resolving the
+        requested packages using pip. The hook **must** not modify the content of the
+        arguments passed to it.
+
+        Some use cases are allowing or disallowing the installation of some packages.
+
+        :param packages: List of resolved packages.
         """
 
     @hookspec
     def groupPackages(  # type: ignore[empty-body]
-        self, packages: 'rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]'
-    ) -> 'rez_pip.compat.Sequence["rez_pip.pip.PackageGroup"]':
+        self,
+        packages: 'rez_pip.compat.MutableSequence["rez_pip.pip.PackageInfo"]',
+    ) -> 'rez_pip.compat.Sequence["rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]"]':
         """
         Merge packages into groups of packages. The name and version of the first package
         in the group will be used as the name and version for the rez package.
 
-        The hook must pop grouped packages out of the "packages" variable.
+        The hook **must** pop grouped packages out of the "packages" variable.
+
+        :param packages: List of resolved packages.
+        :returns: A list of package groups.
         """
 
     @hookspec
     def cleanup(
         self, dist: "rez_pip.compat.importlib_metadata.Distribution", path: str
     ) -> None:
-        """Cleanup installed distribution"""
+        """
+        Cleanup a package post-installation.
+
+        :param dist: Python distribution.
+        :param path: Root path of the rez variant.
+        """
 
     @hookspec
     def metadata(self, package: rez.package_maker.PackageMaker) -> None:
         """
         Modify/inject metadata in the rez package. The plugin is expected to modify
         "package" in place.
+
+        :param package: An instanciate PackageMaker.
         """
 
 

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -140,7 +140,11 @@ def _getHookImplementations() -> typing.Dict[str, typing.List[str]]:
 
     implementations = {}
     for name, plugin in manager.list_name_plugin():
-        implementations[name] = [
-            caller.name for caller in manager.get_hookcallers(plugin)
-        ]
+        hookcallers = manager.get_hookcallers(plugin)
+
+        # hookcallers will never be None because we get the names from list_name_plugin.
+        # But it silences mypy.
+        assert hookcallers is not None
+
+        implementations[name] = [caller.name for caller in hookcallers]
     return implementations

--- a/src/rez_pip/plugins/__init__.py
+++ b/src/rez_pip/plugins/__init__.py
@@ -35,14 +35,14 @@ hookimpl = typing.cast(typing.Callable[[F], F], pluggy.HookimplMarker("rez-pip")
 @dataclasses.dataclass(frozen=True)
 class CleanupAction:
     """
-    Cleanup hook action. If you want to to any cleanup from a cleanup hook
-    you need ot return this.
+    Cleanup hook action. If you want to do any cleanup from a cleanup hook
+    you need to return this from the :func:`cleanup` hook.
     """
 
     #: Operation to perform.
     op: typing.Literal["remove"]
 
-    #: Path to on which to perform the operation.
+    #: Path on which to perform the operation.
     path: str
 
 
@@ -101,8 +101,8 @@ class PluginSpec:
         self, dist: rez_pip.compat.importlib_metadata.Distribution, path: str
     ) -> rez_pip.compat.Sequence[CleanupAction]:
         """
-        Cleanup a package post-installation. Do not do any files/directories from this hook.
-        rez-pip will take care of deleting stuff for you.
+        Cleanup a package post-installation. Do not delete any files/directories from this hook.
+        Return the list of actions you want to perform and let rez-pip perform them.
 
         :param dist: Python distribution.
         :param path: Root path of the rez variant.

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -1,5 +1,5 @@
 import os
-import sys
+import typing
 import shutil
 import logging
 
@@ -7,10 +7,8 @@ import packaging.utils
 
 import rez_pip.plugins
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
+if typing.TYPE_CHECKING:
+    from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import shutil
+
+import packaging.utils
+
+import rez_pip.plugins
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata
+
+
+@rez_pip.plugins.hookimpl
+def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
+    if packaging.utils.canonicalize_name(dist.name) == "shiboken6":
+        path = os.path.join(path, "python", "PySide6")
+        print(f"Removing {path!r}")
+        shutil.rmtree(path)

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -1,3 +1,6 @@
+"""shiboken6 plugin.
+"""
+
 from __future__ import annotations
 
 import os

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import typing
 import shutil

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -14,7 +14,7 @@ _LOG = logging.getLogger(__name__)
 
 
 @rez_pip.plugins.hookimpl
-def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
+def cleanup(dist: "importlib_metadata.Distribution", path: str) -> None:
     if packaging.utils.canonicalize_name(dist.name) != "shiboken6":
         return
 

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -19,15 +19,16 @@ _LOG = logging.getLogger(__name__)
 
 
 @rez_pip.plugins.hookimpl
-def cleanup(dist: "importlib_metadata.Distribution", path: str) -> None:
+def cleanup(
+    dist: "importlib_metadata.Distribution", path: str
+) -> typing.List[rez_pip.plugins.CleanupAction]:
     if packaging.utils.canonicalize_name(dist.name) != "shiboken6":
-        return
+        return []
 
     # Remove PySide6 from shiboken6 packages...
     # shiboken6 >=6.3, <6.6.2 were shipping some PySide6 folders by mistake.
     # Not removing these extra folders would stop python from being able to import
     # the correct PySide6 (that lives in a separate rez package).
-    path = os.path.join(path, "python", "PySide6")
-    if os.path.exists(path):
-        _LOG.debug(f"Removing {path!r}")
-        shutil.rmtree(path)
+    return [
+        rez_pip.plugins.CleanupAction("remove", os.path.join(path, "python", "PySide6"))
+    ]

--- a/src/rez_pip/plugins/shiboken6.py
+++ b/src/rez_pip/plugins/shiboken6.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import logging
 
 import packaging.utils
 
@@ -11,10 +12,19 @@ if sys.version_info >= (3, 10):
 else:
     import importlib_metadata
 
+_LOG = logging.getLogger(__name__)
+
 
 @rez_pip.plugins.hookimpl
 def cleanup(dist: importlib_metadata.Distribution, path: str) -> None:
-    if packaging.utils.canonicalize_name(dist.name) == "shiboken6":
-        path = os.path.join(path, "python", "PySide6")
-        print(f"Removing {path!r}")
+    if packaging.utils.canonicalize_name(dist.name) != "shiboken6":
+        return
+
+    # Remove PySide6 from shiboken6 packages...
+    # shiboken6 >=6.3, <6.6.2 were shipping some PySide6 folders by mistake.
+    # Not removing these extra folders would stop python from being able to import
+    # the correct PySide6 (that lives in a separate rez package).
+    path = os.path.join(path, "python", "PySide6")
+    if os.path.exists(path):
+        _LOG.debug(f"Removing {path!r}")
         shutil.rmtree(path)

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -119,8 +119,6 @@ def createPackage(
                 shutil.copyfile(srcAbsolute, dest)
                 shutil.copystat(srcAbsolute, dest)
 
-            rez_pip.plugins.getHook().cleanup(dist=dist, path=path)
-
     with rez.package_maker.make_package(
         name, packagesPath, make_root=make_root, skip_existing=True, warn_on_skip=False
     ) as pkg:

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -23,7 +23,7 @@ _LOG = logging.getLogger(__name__)
 
 
 def createPackage(
-    packageGroup: rez_pip.pip.PackageGroup,
+    packageGroup: rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact],
     pythonVersion: rez.version.Version,
     installedWheelsDir: str,
     prefix: typing.Optional[str] = None,

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -1,16 +1,10 @@
 import os
-import sys
 import copy
 import shutil
 import typing
 import logging
 import pathlib
 import itertools
-
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 import rez.config
 import rez.version
@@ -21,6 +15,7 @@ import rez.resolved_context
 import rez_pip.pip
 import rez_pip.utils
 import rez_pip.plugins
+from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import copy
 import shutil

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -1,12 +1,6 @@
-import sys
 import typing
 import logging
 import dataclasses
-
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 import rez.system
 import rez.version
@@ -15,6 +9,9 @@ import packaging.specifiers
 import packaging.requirements
 
 import rez_pip.install
+
+if typing.TYPE_CHECKING:
+    from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
 

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -14,6 +14,8 @@ import packaging.version
 import packaging.specifiers
 import packaging.requirements
 
+import rez_pip.install
+
 _LOG = logging.getLogger(__name__)
 
 
@@ -466,7 +468,6 @@ def convertMarker(marker: str) -> typing.List[str]:
 def getRezRequirements(
     installedDist: importlib_metadata.Distribution,
     pythonVersion: rez.version.Version,
-    isPure: bool,
     nameCasings: typing.Optional[typing.List[str]] = None,
 ) -> RequirementsDict:
     """Get requirements of the given dist, in rez-compatible format.
@@ -517,6 +518,7 @@ def getRezRequirements(
     # python build frontends during install
     has_entry_points_scripts = bool(installedDist.entry_points)
 
+    isPure = rez_pip.install.isWheelPure(installedDist)
     # assume package is platform- and arch- specific if it isn't pure python
     if not isPure or has_entry_points_scripts:
         sys_requires.update(["platform", "arch"])

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -6,6 +6,7 @@ import dataclasses
 
 import rez.system
 import rez.version
+import rich.console
 import packaging.version
 import packaging.specifiers
 import packaging.requirements
@@ -16,6 +17,9 @@ if typing.TYPE_CHECKING:
     from rez_pip.compat import importlib_metadata
 
 _LOG = logging.getLogger(__name__)
+
+
+CONSOLE = rich.console.Console()
 
 
 @dataclasses.dataclass

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -463,7 +463,7 @@ def convertMarker(marker: str) -> typing.List[str]:
 
 
 def getRezRequirements(
-    installedDist: importlib_metadata.Distribution,
+    installedDist: "importlib_metadata.Distribution",
     pythonVersion: rez.version.Version,
     nameCasings: typing.Optional[typing.List[str]] = None,
 ) -> RequirementsDict:

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 import logging
 import dataclasses

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import urllib.request
 
 import pytest
 import rez.config
+import rez.system
 import rez.packages
 import rez.package_bind
 import rez.package_maker
@@ -132,6 +133,13 @@ def hardenRezConfig(tmp_path_factory: pytest.TempPathFactory):
     )
     with rez.config._replace_config(defaultConfig):
         yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def resetRez():
+    """Reset rez caches to make sure we don't leak anything between tests"""
+    yield
+    rez.system.system.clear_caches()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ import rez.packages
 import rez.package_bind
 import rez.package_maker
 
+import rez_pip.utils
+
 from . import utils
 
 DATA_ROOT_DIR = os.path.join(os.path.dirname(__file__), "data")
@@ -34,6 +36,12 @@ def pytest_runtest_makereport(item: pytest.Item, call):
     # store test results for each phase of a call, which can
     # be "setup", "call", "teardown"
     item.stash.setdefault(phaseReportKey, {})[rep.when] = rep
+
+
+@pytest.fixture(scope="function", autouse=True)
+def patchRichConsole(monkeypatch: pytest.MonkeyPatch):
+    """Patch the rich console so that it doesn't wrap long lines"""
+    monkeypatch.setattr(rez_pip.utils.CONSOLE, "width", 1000)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,9 @@ def patchRichConsole(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(scope="session")
-def index(tmpdir_factory: pytest.TempdirFactory) -> utils.PyPIIndex:
+def index(
+    tmpdir_factory: pytest.TempdirFactory, printer_session: typing.Callable[[str], None]
+) -> utils.PyPIIndex:
     """Build PyPI Index and return the path"""
 
     srcPackages = os.path.join(DATA_ROOT_DIR, "src_packages")
@@ -54,7 +56,9 @@ def index(tmpdir_factory: pytest.TempdirFactory) -> utils.PyPIIndex:
 
     for pkg in os.listdir(srcPackages):
         dest = indexPath.mkdir(pkg)
-        utils.buildPackage(pkg, os.fspath(dest))
+        printer_session(f"Building {pkg!r}...")
+        wheel = utils.buildPackage(pkg, os.fspath(dest))
+        printer_session(f"Built {pkg!r} at {wheel!r}")
 
     return utils.PyPIIndex(pathlib.Path(indexPath.strpath))
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,5 +1,3 @@
-import typing
-
 import pluggy
 
 import rez_pip.plugins

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -1,0 +1,26 @@
+import typing
+
+import pluggy
+
+import rez_pip.plugins
+
+
+def test_getManager():
+    assert isinstance(rez_pip.plugins.getManager(), pluggy.PluginManager)
+
+
+def test_getHook():
+    assert isinstance(rez_pip.plugins.getHook(), pluggy.HookRelay)
+
+
+def test_getHookImplementations():
+    implementations = rez_pip.plugins._getHookImplementations()
+    assert implementations == {
+        "rez_pip.PySide6": [
+            "cleanup",
+            "groupPackages",
+            "postPipResolve",
+            "prePipResolve",
+        ],
+        "rez_pip.shiboken6": ["cleanup"],
+    }

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -17,6 +17,7 @@ def test_getHookImplementations():
         "rez_pip.PySide6": [
             "cleanup",
             "groupPackages",
+            "patches",
             "postPipResolve",
             "prePipResolve",
         ],

--- a/tests/plugins/test_pyside6.py
+++ b/tests/plugins/test_pyside6.py
@@ -1,0 +1,220 @@
+import sys
+import typing
+import pathlib
+
+import pytest
+
+import rez_pip.pip
+import rez_pip.plugins
+import rez_pip.exceptions
+
+from . import utils
+
+
+if sys.version_info[:2] < (3, 8):
+    import mock
+else:
+    from unittest import mock
+
+
+@pytest.fixture(scope="module")
+def setupPluginManager():
+    yield utils.initializePluginManager("pyside6")
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        ("asd",),
+        ("pyside6",),
+        ("PysiDe6",),
+        ("pyside6", "pyside6-addons"),
+        ("pyside6", "pyside6-essentials"),
+        ("pyside6", "pyside6-essentials", "pyside6-addons"),
+        ("pyside6", "pyside6-addons", "asdasdad"),
+    ],
+)
+def test_prePipResolve_noop(packages: typing.Tuple[str, ...]):
+    rez_pip.plugins.getHook().prePipResolve(packages=packages)
+
+
+@pytest.mark.parametrize("packages", [("pyside6-addons",), ("PysiDe6_essentials",)])
+def test_prePipResolve_raises(packages: typing.Tuple[str, ...]):
+    with pytest.raises(rez_pip.exceptions.RezPipError):
+        rez_pip.plugins.getHook().prePipResolve(packages=packages)
+
+
+def fakePackage(name: str, **kwargs) -> mock.Mock:
+    value = mock.MagicMock()
+    value.configure_mock(name=name, **kwargs)
+    return value
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        (fakePackage("asd"),),
+        (fakePackage("pyside6"),),
+        (fakePackage("PysiDe6"),),
+        (fakePackage("pyside6"), fakePackage("pyside6-addons")),
+        (fakePackage("pyside6"), fakePackage("pyside6-essentials")),
+        (
+            fakePackage("pyside6"),
+            fakePackage("pyside6-essentials"),
+            fakePackage("pyside6-addons"),
+        ),
+        (
+            fakePackage("pyside6"),
+            fakePackage("pyside6-addons"),
+            fakePackage("asdasdad"),
+        ),
+    ],
+)
+def test_postPipResolve_noop(packages: typing.Tuple[str, ...]):
+    rez_pip.plugins.getHook().postPipResolve(packages=packages)
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [
+        (fakePackage("pyside6-addons"),),
+        (fakePackage("PysiDe6_essentials"),),
+        (fakePackage("PysiDe6_essentials"), fakePackage("asd")),
+    ],
+)
+def test_postPipResolve_raises(packages: typing.Tuple[str, ...]):
+    with pytest.raises(rez_pip.exceptions.RezPipError):
+        rez_pip.plugins.getHook().postPipResolve(packages=packages)
+
+
+@pytest.mark.parametrize(
+    "packages",
+    [[fakePackage("asd")]],
+)
+def test_groupPackages_noop(packages: typing.List[str]):
+    assert rez_pip.plugins.getHook().groupPackages(packages=packages) == [
+        [rez_pip.pip.PackageGroup(tuple())]
+    ]
+
+
+class FakePackageInfo:
+    def __init__(self, name: str, version: str):
+        self.name = name
+        self.version = version
+
+    def __eq__(self, value):
+        return self.name == value.name and self.version == value.version
+
+
+@pytest.mark.parametrize(
+    "packages,expectedGroups",
+    [
+        [
+            [fakePackage("pyside6", version="1")],
+            [[rez_pip.pip.PackageGroup((FakePackageInfo("pyside6", "1"),))]],
+        ],
+        [
+            [
+                fakePackage("pyside6", version="1"),
+                fakePackage("pyside6_addons", version="1"),
+            ],
+            [
+                [
+                    rez_pip.pip.PackageGroup(
+                        (
+                            FakePackageInfo("pyside6", "1"),
+                            FakePackageInfo("pyside6_addons", "1"),
+                        )
+                    )
+                ]
+            ],
+        ],
+        [
+            [
+                fakePackage("pyside6", version="1"),
+                fakePackage("pyside6_essentials", version="1"),
+            ],
+            [
+                [
+                    rez_pip.pip.PackageGroup(
+                        (
+                            FakePackageInfo("pyside6", "1"),
+                            FakePackageInfo("pyside6_essentials", "1"),
+                        )
+                    )
+                ]
+            ],
+        ],
+        [
+            [
+                fakePackage("pyside6", version="1"),
+                fakePackage("pyside6_essentials", version="1"),
+                fakePackage("pyside6-Addons", version="1"),
+            ],
+            [
+                [
+                    rez_pip.pip.PackageGroup(
+                        (
+                            FakePackageInfo("pyside6", "1"),
+                            FakePackageInfo("pyside6_essentials", "1"),
+                            FakePackageInfo("pyside6-Addons", "1"),
+                        )
+                    )
+                ]
+            ],
+        ],
+        [
+            [
+                fakePackage("pyside6", version="1"),
+                fakePackage("asdasd", version=2),
+                fakePackage("pyside6_essentials", version="1"),
+                fakePackage("pyside6-Addons", version="1"),
+            ],
+            [
+                [
+                    rez_pip.pip.PackageGroup(
+                        (
+                            FakePackageInfo("pyside6", "1"),
+                            FakePackageInfo("pyside6_essentials", "1"),
+                            FakePackageInfo("pyside6-Addons", "1"),
+                        )
+                    )
+                ]
+            ],
+        ],
+    ],
+)
+def test_groupPackages(
+    packages: typing.List[str], expectedGroups: typing.List[rez_pip.pip.PackageGroup]
+):
+    data = rez_pip.plugins.getHook().groupPackages(packages=packages)
+    assert data == expectedGroups
+
+
+@pytest.mark.parametrize("package", [fakePackage("asd")])
+def test_cleanup_noop(package, tmp_path: pathlib.Path):
+    (tmp_path / "python" / "shiboken6").mkdir(parents=True)
+    (tmp_path / "python" / "shiboken6_generator").mkdir(parents=True)
+
+    rez_pip.plugins.getHook().cleanup(dist=package, path=tmp_path)
+
+    assert (tmp_path / "python" / "shiboken6").exists()
+    assert (tmp_path / "python" / "shiboken6_generator").exists()
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        fakePackage("pyside6"),
+        fakePackage("pyside6_essentials"),
+        fakePackage("PySiDe6-AddoNs"),
+    ],
+)
+def test_cleanup(package, tmp_path: pathlib.Path):
+    (tmp_path / "python" / "shiboken6").mkdir(parents=True)
+    (tmp_path / "python" / "shiboken6_generator").mkdir(parents=True)
+
+    rez_pip.plugins.getHook().cleanup(dist=package, path=tmp_path)
+
+    assert not (tmp_path / "python" / "shiboken6").exists()
+    assert not (tmp_path / "python" / "shiboken6_generator").exists()

--- a/tests/plugins/test_pyside6.py
+++ b/tests/plugins/test_pyside6.py
@@ -17,7 +17,7 @@ else:
     from unittest import mock
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def setupPluginManager():
     yield utils.initializePluginManager("pyside6")
 

--- a/tests/plugins/test_shiboken6.py
+++ b/tests/plugins/test_shiboken6.py
@@ -16,7 +16,7 @@ else:
     from unittest import mock
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def setupPluginManager():
     yield utils.initializePluginManager("shiboken6")
 

--- a/tests/plugins/test_shiboken6.py
+++ b/tests/plugins/test_shiboken6.py
@@ -1,0 +1,52 @@
+import sys
+import pathlib
+
+import pytest
+
+import rez_pip.pip
+import rez_pip.plugins
+import rez_pip.exceptions
+
+from . import utils
+
+
+if sys.version_info[:2] < (3, 8):
+    import mock
+else:
+    from unittest import mock
+
+
+@pytest.fixture(scope="module")
+def setupPluginManager():
+    yield utils.initializePluginManager("shiboken6")
+
+
+def fakePackage(name: str, **kwargs) -> mock.Mock:
+    value = mock.MagicMock()
+    value.configure_mock(name=name, **kwargs)
+    return value
+
+
+@pytest.mark.parametrize("package", [fakePackage("asd")])
+def test_cleanup_noop(package, tmp_path: pathlib.Path):
+    (tmp_path / "python" / "PySide6").mkdir(parents=True)
+
+    rez_pip.plugins.getHook().cleanup(dist=package, path=tmp_path)
+
+    assert (tmp_path / "python" / "PySide6").exists()
+
+
+@pytest.mark.parametrize(
+    "package",
+    [
+        fakePackage("shiboken6"),
+        fakePackage("shiboken6_essentials"),
+        fakePackage("ShIbOkEn6-AddoNs"),
+    ],
+)
+def test_cleanup(package, tmp_path: pathlib.Path):
+    (tmp_path / "python" / "PySide6").mkdir(parents=True)
+
+    rez_pip.plugins.getHook().cleanup(dist=package, path=tmp_path)
+
+    assert not (tmp_path / "python" / "shiboken6").exists()

--- a/tests/plugins/utils.py
+++ b/tests/plugins/utils.py
@@ -1,0 +1,18 @@
+import rez_pip.plugins
+
+
+def initializePluginManager(name: str):
+    """Initialize a plugin manager and clear the cache before exiting the function
+
+    :param name: Name of the plugin to load.
+    """
+    manager = rez_pip.plugins.getManager()
+    for name, plugin in manager.list_name_plugin():
+        if not name.startswith(f"rez-pip.plugins.{name}"):
+            manager.unregister(plugin)
+
+    try:
+        yield manager
+    finally:
+        del manager
+        rez_pip.plugins.getManager.cache_clear()

--- a/tests/sitecustomize.py
+++ b/tests/sitecustomize.py
@@ -1,0 +1,5 @@
+"""Needed to corectly track coverage in subprocesses from the integration tests"""
+
+import coverage
+
+coverage.process_startup()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import subprocess
 import unittest.mock
 
 import pytest
-import rich.console
 import packaging.version
 
 import rez_pip.cli
@@ -319,10 +318,10 @@ def test_debug(capsys: pytest.CaptureFixture, monkeypatch: pytest.MonkeyPatch):
             unittest.mock.Mock(stdout="mocked pip config list"),
         ),
     ) as mocked:
-        rez_pip.cli._debug(
-            argparse.Namespace(pip=None, python_version="2.7+"),
-            console=rich.console.Console(),
+        monkeypatch.setattr(
+            sys, "argv", ["rez-pip", "--debug-info", "asd", "--python-version", "2.7+"]
         )
+        assert rez_pip.cli.run() == 0
 
     assert mocked.call_args_list == [
         unittest.mock.call(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,6 +26,7 @@ def test_parseArgs_empty():
     assert vars(args) == {
         "constraint": None,
         "keep_tmp_dirs": False,
+        "list_plugins": False,
         "log_level": "info",
         "packages": [],
         "pip": rez_pip.pip.getBundledPip(),
@@ -45,6 +46,7 @@ def test_parseArgs_packages(packages):
     assert vars(args) == {
         "constraint": None,
         "keep_tmp_dirs": False,
+        "list_plugins": False,
         "log_level": "info",
         "packages": packages,
         "pip": rez_pip.pip.getBundledPip(),
@@ -64,6 +66,7 @@ def test_parseArgs_no_package_with_requirements(files):
     assert vars(args) == {
         "constraint": None,
         "keep_tmp_dirs": False,
+        "list_plugins": False,
         "log_level": "info",
         "packages": [],
         "pip": rez_pip.pip.getBundledPip(),
@@ -82,6 +85,7 @@ def test_parseArgs_constraints():
     assert vars(args) == {
         "constraint": ["asd", "adasdasd"],
         "keep_tmp_dirs": False,
+        "list_plugins": False,
         "log_level": "info",
         "packages": [],
         "pip": rez_pip.pip.getBundledPip(),
@@ -102,6 +106,7 @@ def test_parseArgs_pipArgs():
     assert vars(args) == {
         "constraint": None,
         "keep_tmp_dirs": False,
+        "list_plugins": False,
         "log_level": "info",
         "packages": [],
         "pip": rez_pip.pip.getBundledPip(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -379,7 +379,7 @@ def test_list_plugins(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFix
     assert (
         output
         == """Name               Hooks
-rez_pip.PySide6    cleanup, groupPackages, postPipResolve, prePipResolve
+rez_pip.PySide6    cleanup, groupPackages, patches, postPipResolve, prePipResolve
 rez_pip.shiboken6  cleanup
 """
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,11 +6,6 @@ import argparse
 import subprocess
 import unittest.mock
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import pytest
 import rich.console
 import packaging.version
@@ -19,6 +14,7 @@ import rez_pip.cli
 import rez_pip.pip
 import rez_pip.rez
 import rez_pip.exceptions
+from rez_pip.compat import importlib_metadata
 
 
 def test_parseArgs_empty():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -367,3 +367,19 @@ rez python packages:
 
 """
     )
+
+
+def test_list_plugins(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture):
+    monkeypatch.setattr(sys, "argv", ["rez-pip", "--list-plugins"])
+
+    assert rez_pip.cli.run() == 0
+
+    output = capsys.readouterr().out
+    output = "\n".join(map(str.strip, output.split("\n")))
+    assert (
+        output
+        == """Name               Hooks
+rez_pip.PySide6    cleanup, groupPackages, postPipResolve, prePipResolve
+rez_pip.shiboken6  cleanup
+"""
+    )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -99,9 +99,14 @@ def test_download(groups: typing.List[Group], tmp_path: pathlib.Path):
 
         new_groups = rez_pip.download.downloadPackages(_groups, os.fspath(tmp_path))
 
-    assert sorted(new_groups) == sorted(groups)
+    assert len(new_groups) == len(groups)
+    assert sum(len(group.packages) for group in new_groups) == sum(
+        len(group.packages) for group in groups
+    )
 
-    wheelsMapping = {os.path.basename(wheel).split(".")[0]: wheel for wheel in wheels}
+    wheelsMapping = {
+        package.name: package.path for group in new_groups for package in group.packages
+    }
 
     for group in groups:
         for package in group.packages:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -9,16 +9,12 @@ if sys.version_info[:2] < (3, 8):
 else:
     from unittest import mock
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import pytest
 import aiohttp
 
 import rez_pip.pip
 import rez_pip.download
+from rez_pip.compat import importlib_metadata
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,6 +1,4 @@
 import os
-import sys
-import glob
 import pathlib
 import platform
 import subprocess
@@ -10,6 +8,7 @@ import installer.utils
 
 import rez_pip.pip
 import rez_pip.install
+from rez_pip.compat import importlib_metadata
 
 from . import utils
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -4,6 +4,7 @@ import platform
 import subprocess
 
 import pytest
+import rez.rex
 import installer.utils
 
 import rez_pip.pip
@@ -59,18 +60,19 @@ def test_console_scripts(
 
     assert os.path.exists(consoleScript), f"{consoleScript!r} does not exists!"
 
+    def injectEnvVars(executor: rez.rex.RexExecutor):
+        executor.env.PYTHONPATH.prepend(os.fspath(installPath / "python"))
+
     code, stdout, _ = ctx.execute_shell(
         command=[consoleScript],
         block=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        parent_environ={
-            "PYTHONPATH": os.fspath(installPath / "python"),
-            "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
-        },
         text=True,
+        actions_callback=injectEnvVars,
     )
 
+    assert code == 0
     # Use dirnames to avoid having to deal woth python vs python2 or python vs python3
     assert os.path.dirname(stdout) == os.path.dirname(
         executable

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,8 @@
 import os
 import re
+import sys
+import typing
+import pathlib
 import platform
 import subprocess
 
@@ -58,3 +61,69 @@ def test_python_packages(pythonRezPackage: str, rezRepo: str):
 
     assert code == 0
     assert stdout.decode("utf-8").strip().lower() == expectedPath.lower()
+
+
+@pytest.mark.parametrize(
+    "packagesToInstall,imports", [[["PySide6"], ["PySide6"]]], ids=["PySide6"]
+)
+def test_installs(
+    pythonRezPackage: str,
+    rezRepo: str,
+    packagesToInstall: typing.List[str],
+    imports: typing.List[str],
+    tmp_path: pathlib.Path,
+    capsys: pytest.CaptureFixture,
+):
+    """End to end integration test"""
+    command = [
+        sys.executable,
+        "-m",
+        "rez_pip",
+        *packagesToInstall,
+        "--prefix",
+        os.fspath(tmp_path),
+        "--python-version",
+        pythonRezPackage,
+    ]
+
+    with capsys.disabled():
+        subprocess.check_call(
+            command,
+            env={
+                "REZ_PACKAGES_PATH": os.pathsep.join([rezRepo, os.fspath(tmp_path)]),
+                "REZ_DISABLE_HOME_CONFIG": "1",
+                "COVERAGE_PROCESS_START": os.path.join(
+                    os.path.dirname(os.path.dirname(__file__)), ".coveragerc"
+                ),
+                "PYTHONPATH": os.path.dirname(__file__),
+            },
+        )
+
+    ctx = rez.resolved_context.ResolvedContext(
+        packagesToInstall + [f"python-{pythonRezPackage}"],
+        package_paths=[rezRepo, os.fspath(tmp_path)],
+    )
+    assert ctx.status == rez.resolved_context.ResolverStatus.solved
+
+    code, stdout, stderr = ctx.execute_shell(
+        command=[
+            "python",
+            "-c",
+            f"import {','.join(imports)}; [print(i.__path__[0]) for i in [{','.join(imports)}]]",
+        ],
+        block=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert code == 0
+    assert all(
+        [line.startswith(os.fspath(tmp_path)) for line in stdout.strip().split("\n")]
+    )
+
+    for index, path in enumerate(stdout.strip().split("\n")):
+        assert path.startswith(
+            os.fspath(tmp_path)
+        ), f"{path!r} does not start with {os.fspath(tmp_path)!r}"
+
+    assert not stderr

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -97,6 +97,7 @@ def test_installs(
     if platform.system() == "Windows":
         # https://stackoverflow.com/a/64706392
         env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+        # Needed for getpass.getuser to work on Windows.
         env["USERNAME"] = os.environ["USERNAME"]
 
     with capsys.disabled():
@@ -119,14 +120,14 @@ def test_installs(
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+    print(stdout)
+    print("****")
+    print(stderr)
     assert code == 0
-    assert all(
-        [line.startswith(os.fspath(tmp_path)) for line in stdout.strip().split("\n")]
-    )
 
-    for index, path in enumerate(stdout.strip().split("\n")):
-        assert path.startswith(
-            os.fspath(tmp_path)
+    for path in stdout.strip().split("\n"):
+        assert path.lower().startswith(
+            os.fspath(tmp_path).lower()
         ), f"{path!r} does not start with {os.fspath(tmp_path)!r}"
 
     assert not stderr

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -86,18 +86,21 @@ def test_installs(
         pythonRezPackage,
     ]
 
+    env = {
+        "REZ_PACKAGES_PATH": os.pathsep.join([rezRepo, os.fspath(tmp_path)]),
+        "REZ_DISABLE_HOME_CONFIG": "1",
+        "COVERAGE_PROCESS_START": os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), ".coveragerc"
+        ),
+        "PYTHONPATH": os.path.dirname(__file__),
+    }
+    if platform.system() == "Windows":
+        # https://stackoverflow.com/a/64706392
+        env["SYSTEMROOT"] = os.environ["SYSTEMROOT"]
+        env["USERNAME"] = os.environ["USERNAME"]
+
     with capsys.disabled():
-        subprocess.check_call(
-            command,
-            env={
-                "REZ_PACKAGES_PATH": os.pathsep.join([rezRepo, os.fspath(tmp_path)]),
-                "REZ_DISABLE_HOME_CONFIG": "1",
-                "COVERAGE_PROCESS_START": os.path.join(
-                    os.path.dirname(os.path.dirname(__file__)), ".coveragerc"
-                ),
-                "PYTHONPATH": os.path.dirname(__file__),
-            },
-        )
+        subprocess.check_call(command, env=env)
 
     ctx = rez.resolved_context.ResolvedContext(
         packagesToInstall + [f"python-{pythonRezPackage}"],

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -15,6 +15,68 @@ import rez_pip.exceptions
 from . import utils
 
 
+@pytest.mark.parametrize(
+    "url,shouldDownload",
+    [
+        (
+            "https://pypi.org/packages/package_a/package_a-1.0.0-py2.py3-none-any.whl",
+            True,
+        ),
+        ("file:///tmp/asd.whl", False),
+    ],
+)
+def test_PackageInfo(url: str, shouldDownload: bool):
+    info = rez_pip.pip.PackageInfo(
+        rez_pip.pip.DownloadInfo(
+            url,
+            rez_pip.pip.ArchiveInfo(
+                "sha256=<val>",
+                {"sha256": "<val>"},
+            ),
+        ),
+        False,
+        True,
+        rez_pip.pip.Metadata(
+            "1.0.0",
+            "package_a",
+        ),
+    )
+
+    assert info.name == "package_a"
+    assert info.version == "1.0.0"
+    assert info.isDownloadRequired() == shouldDownload
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://pypi.org/packages/package_a/package_a-1.0.0-py2.py3-none-any.whl",
+        "file:///tmp/package_a-1.0.0-py2.py3-none-any.whl",
+    ],
+)
+def test_DownloadedArtifact(url: str):
+    info = rez_pip.pip.DownloadedArtifact(
+        rez_pip.pip.DownloadInfo(
+            url,
+            rez_pip.pip.ArchiveInfo(
+                "sha256=<val>",
+                {"sha256": "<val>"},
+            ),
+        ),
+        False,
+        True,
+        rez_pip.pip.Metadata(
+            "1.0.0",
+            "package_a",
+        ),
+        "/tmp/package_a-1.0.0-py2.py3-none-any.whl",
+    )
+
+    assert info.name == "package_a"
+    assert info.version == "1.0.0"
+    assert info.path == "/tmp/package_a-1.0.0-py2.py3-none-any.whl"
+
+
 def test_getBundledPip():
     """Test that the bundled pip exists and can be executed"""
     assert os.path.exists(rez_pip.pip.getBundledPip())

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -6,10 +6,10 @@ import typing
 import pathlib
 import subprocess
 
-import rich
 import pytest
 
 import rez_pip.pip
+import rez_pip.utils
 import rez_pip.exceptions
 
 from . import utils
@@ -232,8 +232,8 @@ def test_getPackages_error(
             ],
         )
 
-    with rich.get_console().capture() as capture:
-        rich.get_console().print(exc.value, soft_wrap=True)
+    with rez_pip.utils.CONSOLE.capture() as capture:
+        rez_pip.utils.CONSOLE.print(exc.value, soft_wrap=True)
 
     match = re.match(
         r"rez_pip\.exceptions\.PipError: Failed to run pip command\: '.*'",

--- a/tests/test_rez.py
+++ b/tests/test_rez.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import stat
 import typing
 import pathlib
@@ -12,14 +11,10 @@ import rez.version
 import rez.packages
 import rez.package_repository
 
-if sys.version_info >= (3, 10):
-    import importlib.metadata as importlib_metadata
-else:
-    import importlib_metadata
-
 import rez_pip.pip
 import rez_pip.rez
 import rez_pip.utils
+from rez_pip.compat import importlib_metadata
 
 
 def test_createPackage(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):


### PR DESCRIPTION
Fixes #64.

Add a new generic plugins system and builtin plugins. The glugin system is based on [pluggy](https://pluggy.readthedocs.io/en/stable/) and has 5 hooks: `prePipResolve`, `postPipResolve`, `groupPackages`, `cleanup`, `patches` and `metadata`.

The 2 builtin plugins are the PySide6 and shiboken6 plugins for correctly installing PySide6>=6.3. The plugins take care of merging all the PySide6 related packages (PySide6, PySide6-Addons and PySide6-Essentials) into one rez package.

```
$ rez-pip2 PySide6 --prefix /tmp/asd --python 3.11 -- --find-links /tmp/wheels --no-index

$ rez-env PySide6 --paths ~/rez_packages:/tmp/asd -- python -c 'import PySide6,shiboken6; print(PySide6); print(shiboken6)'
<module 'PySide6' from '/tmp/asd/PySide6/6.6.1/9645a50b415bcaad6bcde791aeb0859a43c56501/python/PySide6/__init__.py'>
<module 'shiboken6' from '/tmp/asd/shiboken6/6.6.1/9645a50b415bcaad6bcde791aeb0859a43c56501/python/shiboken6/__init__.py'>
```
:tada:

~**This only works on Linux and macOS. On Windows, it works with Python 3.7 but not 3.8 and above. PySide6 on Windows makes use of `os.add_dll_directory`...**~

Additionally, add support for installing local wheels. Considering that PySide is a big package, I needed that functionality to speed up the development of the plugin system.

TODOs:
* Add option to disable plugins/hooks
* Test if builtin plugins can be overridden
* ~Test on Windows~
* ~Write tests~
* ~Cleanup the code~
* ~Write docs (and automatically generate docs for builtin plugins).~