### PR TITLE
Explicitly error out if no package family can be found or if no version is within the requested range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+junit.xml
 
 # Environments
 .env


### PR DESCRIPTION
Fixes #118

Handle two different cases while searching for python packages:

* Raise an explicit error if no package family named "python" is found
* Raise an explicit error if no version is found within the requested range

This will avoid rez-pip doing "nothing" and will instead error out.