### PR TITLE
Fix logging bugs introduced by PR #91

### DIFF
--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -370,7 +370,10 @@ def run() -> int:
         _validateArgs(args)
 
         handler = rich.logging.RichHandler(
-            show_time=False, markup=True, show_path=False
+            show_time=False,
+            markup=True,
+            show_path=False,
+            console=rez_pip.utils.CONSOLE,
         )
         handler.setFormatter(logging.Formatter(fmt="%(message)s"))
 

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -240,9 +240,11 @@ def _run(args: argparse.Namespace, pipArgs: list[str], pipWorkArea: str) -> None
                 else:
                     downloaded += 1
 
-        _LOG.info(
-            f"[bold]Downloaded {downloaded} wheels, skipped {foundLocally} because they resolved to local files"
-        )
+        message = f"Downloaded {downloaded} wheels"
+        if foundLocally:
+            message += f"skipped {foundLocally} because they resolved to local files"
+
+        _LOG.info(f"[bold]{message}")
 
         with rez_pip.utils.CONSOLE.status(
             f"[bold]Installing wheels into {installedWheelsDir!r}"


### PR DESCRIPTION
Fixes #119

It was caused by two dumb mistakes I made in #91:
1. I forgot to pass the shared Rich `console` to the Rich logging handler. This caused all logs to mangle the progress bar, status, etc.
2. I unnecessarily made the download complicated by nesting futures in groups. This was no necessary.