### PR TITLE
Support PEP 639

### DIFF
--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -19,6 +19,7 @@ It is able to to convert most of the `PyPA core metadata`_:
 * Maintainer
 * Maintainer-email
 * License
+* License-Expression
 * Home-page
 * Project-URL
 * Download-URL
@@ -84,11 +85,19 @@ Link: https://packaging.python.org/en/latest/specifications/core-metadata/#licen
 
 If present, it will be stored as in a custom attributed called ``license`` as is.
 
+If not present, ``rez-pip`` will look into ``License-Expression``.
+
+License-Expression
+==================
+
+Link: https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
+
+If present, it will be stored as in a custom attributed called ``license`` as is.
+
 If not present, ``rez-pip`` will look into `classifiers`_ for any value that starts with ``License ::``.
 If one is found, it will be used as the license. If more than one is found, ``license`` will not be set.
 
 .. _classifiers: https://packaging.python.org/en/latest/specifications/core-metadata/#classifier-multiple-use
-
 
 Home-page
 =========

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -237,6 +237,9 @@ def _convertMetadata(
     if "License" in dist.metadata:
         metadata["license"] = dist.metadata["License"]
         del originalMetadata["license"]
+    elif "License-Expression" in dist.metadata:
+        metadata["license"] = dist.metadata["License-Expression"]
+        del originalMetadata["license_expression"]
     else:
         licenseClassifiers = [
             item.split("::")[-1].strip()

--- a/tests/test_rez.py
+++ b/tests/test_rez.py
@@ -177,6 +177,8 @@ def test_convertMetadata_nothing_to_convert(monkeypatch: pytest.MonkeyPatch):
         ],
         # License from License field
         ["License: Apache-2.0", {"license": "Apache-2.0"}, {}],
+        # License from License-Expression field
+        ["License-Expression: Apache-2.0", {"license": "Apache-2.0"}, {}],
         [
             "Classifier: asdasd :: something",
             {},


### PR DESCRIPTION
PEP 639 adds a new core metadata named `License-Expression`.