### PR TITLE
Fix for cases when "Requires-Python" is not part of metadata

### DIFF
--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -624,9 +624,7 @@ def getRezRequirements(
         #
         sys_variant_requires.append("python-%s" % str(pythonVersion.trim(2)))
     else:
-        requiresPython = None
-        if "Requires-Python" in installedDist.metadata:
-            requiresPython = installedDist.metadata["Requires-Python"]
+        requiresPython = installedDist.metadata.get("Requires-Python")
         if requiresPython:
             result_requires.append(
                 f"python-{pythonSpecifierToRezRequirement(packaging.specifiers.SpecifierSet(requiresPython))}"

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -624,7 +624,9 @@ def getRezRequirements(
         #
         sys_variant_requires.append("python-%s" % str(pythonVersion.trim(2)))
     else:
-        requiresPython = installedDist.metadata["Requires-Python"]
+        requiresPython = None
+        if "Requires-Python" in installedDist.metadata:
+            requiresPython = installedDist.metadata["Requires-Python"]
         if requiresPython:
             result_requires.append(
                 f"python-{pythonSpecifierToRezRequirement(packaging.specifiers.SpecifierSet(requiresPython))}"


### PR DESCRIPTION
Fixes https://github.com/JeanChristopheMorinPerso/rez-pip/issues/243

Use `get` to access the metadata key `Requires-Pyhon`.