### PR TITLE
fix: add system variants when marker evaluate is false

### DIFF
--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -555,9 +555,22 @@ def getRezRequirements(
         reqs = normalizeRequirement(req_)
 
         for req in reqs:
-            # skip if env marker is present and doesn't evaluate
-            if req.marker and not req.marker.evaluate(environment=marker_env):
-                continue
+            # Inspect marker(s) to see if this requirement should be varianted.
+            # Markers may also cause other system requirements to be added to
+            # the variant.
+            #
+            to_variant = False
+
+            if req.marker:
+                marker_reqs = convertMarker(str(req.marker))
+
+                if marker_reqs:
+                    sys_requires.update(marker_reqs)
+                    to_variant = True
+
+                # skip if env marker is present and doesn't evaluate
+                if not req.marker.evaluate(environment=marker_env):
+                    continue
 
             # skip if req is conditional on extras that weren't requested
             if req.conditional_extras and not (
@@ -572,19 +585,6 @@ def getRezRequirements(
                     "not yet supported"
                 )
                 continue
-
-            # Inspect marker(s) to see if this requirement should be varianted.
-            # Markers may also cause other system requirements to be added to
-            # the variant.
-            #
-            to_variant = False
-
-            if req.marker:
-                marker_reqs = convertMarker(str(req.marker))
-
-                if marker_reqs:
-                    sys_requires.update(marker_reqs)
-                    to_variant = True
 
             # remap the requirement name
             remapped = name_mapping.get(req.name.lower())
@@ -616,7 +616,7 @@ def getRezRequirements(
         sys_variant_requires.append(f"os-{_system.os}")
 
     # JC: TODO: This is a modified version based on rez. It needs to be verified.
-    if not isPure:
+    if "python" in sys_requires or not isPure:
         # Add python variant requirement. Note that this is always MAJOR.MINOR,
         # because to do otherwise would mean analysing any present env markers.
         # This could become quite complicated, and could also result in strange


### PR DESCRIPTION
See issue https://github.com/JeanChristopheMorinPerso/rez-pip/issues/245

When a python package has a dependency like `"typing-extensions~=4.12 ; python_version < '3.12'"` the python version needs to be part of the variant even when the marker evaluation is false.  Without keeping the python version variant python-3.11 would have a variant of `['typing_extensions-4.12+<5']` and python-3.13 would not have a variant.  The python-3.13 package install would fail because you can not install a package without a variant into a package with a variant.  With the fix python-3.11 has a variant of `['python-3.11', 'typing_extensions-4.12+<5']` and python-3.13 has a variant of `['python-3.13']`

This does not address the issue mentioned in the code:
```python
# Add python variant requirement. Note that this is always MAJOR.MINOR,
# because to do otherwise would mean analysing any present env markers.
# This could become quite complicated, and could also result in strange
# python version ranges in the variants.
```