### PR TITLE
feat: use pip for downloads

### DIFF
--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -249,7 +249,7 @@ def _run(args: argparse.Namespace, pipArgs: list[str], pipWorkArea: str) -> None
 
         packageGroups: list[
             rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]
-        ] = rez_pip.download.downloadPackages(_packageGroups, wheelsDir)
+        ] = rez_pip.download.downloadPackages(_packageGroups, wheelsDir, runner)
 
         foundLocally = downloaded = 0
         for group in packageGroups:

--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -207,14 +207,18 @@ def _run(args: argparse.Namespace, pipArgs: list[str], pipWorkArea: str) -> None
         installedWheelsDir = os.path.join(pipWorkArea, "installed", pythonVersion)
         os.makedirs(installedWheelsDir, exist_ok=True)
 
+        runner = rez_pip.pip.PipRunner(
+            pythonExecutable=os.fspath(pythonExecutable),
+            pythonVersion=pythonVersion,
+            pip=args.pip,
+        )
+
         with rez_pip.utils.CONSOLE.status(
             f"[bold]Resolving dependencies for {rich.markup.escape(', '.join(args.packages))} (python-{pythonVersion})"
         ):
             packages = rez_pip.pip.getPackages(
+                runner,
                 args.packages,
-                args.pip,
-                pythonVersion,
-                os.fspath(pythonExecutable),
                 args.requirement or [],
                 args.constraint or [],
                 pipArgs,

--- a/src/rez_pip/download.py
+++ b/src/rez_pip/download.py
@@ -14,6 +14,7 @@ import collections
 import aiohttp
 import rich.progress
 
+from rez_pip import exceptions
 import rez_pip.pip
 import rez_pip.utils
 from rez_pip.compat import importlib_metadata
@@ -25,18 +26,19 @@ _lock = asyncio.Lock()
 def downloadPackages(
     packageGroups: list[rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo]],
     dest: str,
+    runner: rez_pip.pip.PipRunner,
 ) -> list[rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]]:
-    return asyncio.run(_downloadPackages(packageGroups, dest))
+    return asyncio.run(_downloadPackages(packageGroups, dest, runner))
 
 
 async def _downloadPackages(
     packageGroups: list[rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo]],
     dest: str,
+    runner: rez_pip.pip.PipRunner,
 ) -> list[rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]]:
-    newPackageGroups: list[rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]] = (
-        []
-    )
-    someFailed = False
+    newPackageGroups: list[
+        rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact]
+    ] = []
 
     async with aiohttp.ClientSession() as session:
         with rich.progress.Progress(
@@ -83,7 +85,6 @@ async def _downloadPackages(
                     groupMapping[index].append(package.name)
 
                     if not package.isDownloadRequired():
-
                         # Note the subtlety of having to pass variables in the function
                         # signature. We can't rely on the scoped variable.
                         async def _return_local(
@@ -104,6 +105,7 @@ async def _downloadPackages(
                                 mainTask,
                                 wheelName,
                                 wheelPath,
+                                runner,
                             )
                         )
 
@@ -132,20 +134,34 @@ async def _downloadPackages(
     return newPackageGroups
 
 
-def getSHA256(path: str) -> str:
+# TODO: Should we support weak hashes md5, sha1, sha224?  Do any repositories still use them?
+HASHES = {"md5", "sha1", "sha224", "sha256", "sha384", "sha512"}
+
+
+def checkHashes(path: str, hashes: dict[str, str]) -> bool:
+    # Accept file without hashes.  The Simple Repository API says each URL SHOULD include a hash and not a MUST
+    if not hashes:
+        return True
+
     buf = bytearray(2**18)  # Reusable buffer to reduce allocations.
     view = memoryview(buf)
 
-    digestobj = hashlib.new("sha256")
+    # Support multiple hash functions on a URL
+    digests = {algo: hashlib.new(algo) for algo in HASHES if algo in hashes}
+
+    # Reject files if all the hashes are unknown
+    if not digests:
+        return False
 
     with open(path, "rb") as fd:
         while True:
             size = fd.readinto(buf)
             if size == 0:
                 break  # EOF
-            digestobj.update(view[:size])
+            for digest in digests.values():
+                digest.update(view[:size])
 
-    return digestobj.hexdigest()
+    return all(digests[algo].hexdigest() == hashes[algo] for algo in digests)
 
 
 async def _download(
@@ -156,18 +172,22 @@ async def _download(
     mainTaskID: rich.progress.TaskID,
     wheelName: str,
     wheelPath: str,
+    runner: rez_pip.pip.PipRunner,
 ) -> rez_pip.pip.DownloadedArtifact | None:
-    # TODO: Handle case where sha256 doesn't exist. We should also support the other supported
-    # hash types.
-    if (
-        os.path.exists(wheelPath)
-        and getSHA256(wheelPath) == package.download_info.archive_info.hashes["sha256"]
+    # TODO: Handle case where hash doesn't exist.
+
+    mainTask = [task for task in progress.tasks if task.id == mainTaskID][0]
+
+    if os.path.exists(wheelPath) and checkHashes(
+        wheelPath, package.download_info.archive_info.hashes
     ):
         _LOG.info(f"{wheelName} found in cache at {wheelPath!r}. Skipping download.")
     else:
         _LOG.debug(
             f"Downloading {package.name}-{package.version} from {package.download_info.url}"
         )
+
+        tryPipFallback = False
 
         async with session.get(
             package.download_info.url,
@@ -176,34 +196,73 @@ async def _download(
                 "User-Agent": f"rez-pip/{importlib_metadata.version('rez-pip')}",
             },
         ) as response:
-            size = int(response.headers.get("content-length", 0))
-            progress.update(taskID, total=size)
-
-            async with _lock:
-                mainTask = [task for task in progress.tasks if task.id == mainTaskID][0]
-
-                progress.update(
-                    mainTaskID,
-                    total=typing.cast(int, mainTask.total) + size,
+            if response.status == 401:
+                _LOG.debug(
+                    f"unauthorized to download {package.download_info.url}. Trying to download with pip."
                 )
-
-            if response.status != 200:
+                tryPipFallback = True
+            elif response.status != 200:
                 _LOG.error(
                     f"failed to download {package.download_info.url}: {response.status} - {response.reason}, {response.request_info}"
                 )
+
+                return None
+            else:
+                size = int(response.headers.get("content-length", 0))
+                progress.update(taskID, total=size)
+
+                async with _lock:
+                    progress.update(
+                        mainTaskID,
+                        total=typing.cast(int, mainTask.total) + size,
+                    )
+
+                with open(wheelPath, "wb") as fd:
+                    async for chunk, asd in response.content.iter_chunks():
+                        if not chunk:
+                            break
+                        _ = fd.write(chunk)
+                        progress.update(taskID, advance=len(chunk))
+                        progress.update(mainTaskID, advance=len(chunk))
+
+        if tryPipFallback:
+            try:
+                await runner.runAsync(
+                    "download",
+                    [
+                        "--no-deps",
+                        "--dest",
+                        os.path.dirname(wheelPath),
+                        f"{package.name}=={package.version}",
+                    ],
+                )
+            except exceptions.PipError as e:
+                _LOG.error(f"failed to download {package.name}-{package.version}: {e}")
+                return None
+            if not os.path.exists(wheelPath):
+                _LOG.error(
+                    f"failed downloading {package.name}-{package.version} to {wheelPath}"
+                )
                 return None
 
-            with open(wheelPath, "wb") as fd:
-                async for chunk, asd in response.content.iter_chunks():
-                    if not chunk:
-                        break
-                    fd.write(chunk)
-                    progress.update(taskID, advance=len(chunk))
-                    progress.update(mainTaskID, advance=len(chunk))
+            size = os.stat(wheelPath).st_size
+            progress.update(taskID, total=size)
+            progress.update(taskID, advance=size)
+            async with _lock:
+                progress.update(
+                    mainTaskID, total=typing.cast(int, mainTask.total) + size
+                )
+            progress.update(mainTaskID, advance=size)
 
-            _LOG.info(
-                f"Downloaded {package.name}-{package.version} to {wheelPath!r} ({os.stat(wheelPath).st_size} bytes)"
+        if not checkHashes(wheelPath, package.download_info.archive_info.hashes):
+            _LOG.error(
+                f"failed to download {package.download_info.url}: invalid file hash"
             )
+            return None
+
+        _LOG.info(
+            f"Downloaded {package.name}-{package.version} to {wheelPath!r} ({os.stat(wheelPath).st_size} bytes)"
+        )
 
     progress.update(taskID, visible=False)
 

--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -8,6 +8,7 @@ import os
 import sys
 import json
 import typing
+import asyncio
 import logging
 import tempfile
 import itertools
@@ -109,6 +110,79 @@ class DownloadedArtifact(PackageInfo):
         return self._localPath
 
 
+@dataclasses.dataclass(frozen=True)
+class PipRunner:
+    pythonExecutable: str
+    pythonVersion: str
+    pip: str
+
+    def command(
+        self,
+        pipCommand: str,
+        arguments: list[str],
+    ) -> list[str]:
+        return [
+            # We need to use the real interpreter because pip can't resolve
+            # markers correctly even if --python-version is provided.
+            # See https://github.com/pypa/pip/issues/11664.
+            self.pythonExecutable,
+            self.pip,
+            pipCommand,
+            "--quiet",
+            "--disable-pip-version-check",
+            "--only-binary=:all:",
+            f"--python-version={self.pythonVersion}" if self.pythonVersion else "",
+            *arguments,
+        ]
+
+    def run(self, pipCommand: str, arguments: list[str]) -> None:
+        command = self.command(pipCommand, arguments)
+
+        _LOG.debug(f"Running {' '.join(command)!r}")
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+        pipOutput: list[str] = []
+        while True:
+            stdout = typing.cast(typing.IO[str], process.stdout).readline()
+            if process.poll() is not None:
+                break
+            if stdout:
+                pipOutput.append(stdout.rstrip())
+                _ = sys.stdout.write(stdout)
+
+        if process.poll() != 0:
+            self.raisePipError(command, "\n".join(pipOutput))
+
+    async def runAsync(self, pipCommand: str, arguments: list[str]) -> None:
+        command = self.command(pipCommand, arguments)
+
+        _LOG.debug(f"Running {' '.join(command)!r}")
+        process = await asyncio.create_subprocess_exec(
+            command[0],
+            *command[1:],
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        stdout, _ = await process.communicate()
+
+        if process.returncode != 0:
+            self.raisePipError(command, stdout.decode())
+
+    @staticmethod
+    def raisePipError(command: list[str], output: str) -> None:
+        raise rez_pip.exceptions.PipError(
+            f"[bold red]Failed to run pip command[/]: {' '.join(command)!r}\n\n"
+            "[bold]Pip reported this[/]:\n\n"
+            f"{output}",
+        )
+
+
 T = typing.TypeVar("T", PackageInfo, DownloadedArtifact)
 
 
@@ -157,10 +231,8 @@ def getBundledPip() -> str:
 
 
 def getPackages(
+    runner: PipRunner,
     packageNames: list[str],
-    pip: str,
-    pythonVersion: str,
-    pythonExecutable: str,
     requirements: list[str],
     constraints: list[str],
     extraArgs: list[str],
@@ -175,53 +247,21 @@ def getPackages(
     # Windows doesn't allow two different processes to write if the file is
     # already opened.
     try:
-        command = [
-            # We need to use the real interpreter because pip can't resolve
-            # markers correctly even if --python-version is provided.
-            # See https://github.com/pypa/pip/issues/11664.
-            pythonExecutable,
-            pip,
+        runner.run(
             "install",
-            "-q",
-            *packageNames,
-            *list(itertools.chain(*zip(["-r"] * len(requirements), requirements))),
-            *list(itertools.chain(*zip(["-c"] * len(constraints), constraints))),
-            "--disable-pip-version-check",
-            "--dry-run",
-            "--ignore-installed",
-            f"--python-version={pythonVersion}" if pythonVersion else "",
-            "--only-binary=:all:",
-            "--target=/tmp/asd",
-            "--disable-pip-version-check",
-            "--report",  # This is the "magic". Pip will generate a JSON with all the resolved URLs.
-            tmpFile,
-            *extraArgs,
-        ]
-
-        _LOG.debug(f"Running {' '.join(command)!r}")
-        process = subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+            [
+                "--dry-run",
+                "--ignore-installed",
+                "--target=/tmp/asd",
+                "--report",  # This is the "magic". Pip will generate a JSON with all the resolved URLs.
+                tmpFile,
+                *packageNames,
+                *list(itertools.chain(*zip(["-r"] * len(requirements), requirements))),
+                *list(itertools.chain(*zip(["-c"] * len(constraints), constraints))),
+                *extraArgs,
+            ],
         )
 
-        pipOutput = []
-        while True:
-            stdout = typing.cast(typing.IO[str], process.stdout).readline()
-            if process.poll() is not None:
-                break
-            if stdout:
-                pipOutput.append(stdout.rstrip())
-                sys.stdout.write(stdout)
-
-        if process.poll() != 0:
-            output = "\n".join(pipOutput)
-            raise rez_pip.exceptions.PipError(
-                f"[bold red]Failed to run pip command[/]: {' '.join(command)!r}\n\n"
-                "[bold]Pip reported this[/]:\n\n"
-                f"{output}",
-            )
         reportContent = _readPipReport(reportPath=tmpFile)
     finally:
         os.remove(tmpFile)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -15,6 +15,7 @@ import aiohttp
 
 import rez_pip.pip
 import rez_pip.download
+import rez_pip.exceptions
 from rez_pip.compat import importlib_metadata
 
 
@@ -26,11 +27,33 @@ def rezPipVersion():
         yield
 
 
+@pytest.fixture
+def runner():
+    runner = unittest.mock.Mock()
+    runner.run = unittest.mock.Mock(
+        side_effect=rez_pip.exceptions.PipError("run should not have been called")
+    )
+    runner.runAsync = unittest.mock.AsyncMock(
+        side_effect=rez_pip.exceptions.PipError("runAsync should not have been called")
+    )
+    return runner
+
+
 class Package:
-    def __init__(self, name: str, content: str, local: bool):
+    def __init__(self, name: str, content: str = ""):
         self.name = name
-        self.content = content
-        self.local = local
+
+        if not content:
+            content = f"{name} data"
+        self.content = content.encode("utf-8")
+
+        hash = hashlib.new("sha256")
+        hash.update(self.content)
+        self.hashes = {"sha256": hash.hexdigest()}
+
+    def write(self, path: pathlib.Path) -> None:
+        with open(path, "wb") as fd:
+            _ = fd.write(self.content)
 
 
 class Group:
@@ -47,22 +70,24 @@ class Group:
 @pytest.mark.parametrize(
     "groups",
     [
-        [Group([Package("package-a", "package-a data", False)])],
+        [Group([Package("package-a")])],
         [
-            Group([Package("package-a", "package-a data", False)]),
-            Group([Package("package-b", "package-b data", False)]),
+            Group([Package("package-a")]),
+            Group([Package("package-b")]),
         ],
     ],
     ids=["one-group-with-one-package", "multiple-groups-with-one-package"],
 )
-def test_download(groups: typing.List[Group], tmp_path: pathlib.Path):
+def test_download(
+    groups: typing.List[Group], tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner
+):
     sideEffects = tuple()
     for group in groups:
         for package in group.packages:
             mockedContent = unittest.mock.MagicMock()
             mockedContent.return_value.__aiter__.return_value = [
                 [
-                    package.content.encode("utf-8"),
+                    package.content,
                     None,
                 ]
             ]
@@ -92,15 +117,19 @@ def test_download(groups: typing.List[Group], tmp_path: pathlib.Path):
                         ),
                         download_info=rez_pip.pip.DownloadInfo(
                             url=f"https://example.com/{package.name}.whl",
-                            archive_info=rez_pip.pip.ArchiveInfo("hash", {}),
+                            archive_info=rez_pip.pip.ArchiveInfo(
+                                "hash", package.hashes
+                            ),
                         ),
                         is_direct=True,
                         requested=True,
                     )
                 )
-            _groups.append(rez_pip.pip.PackageGroup(infos))
+            _groups.append(rez_pip.pip.PackageGroup(tuple(infos)))
 
-        new_groups = rez_pip.download.downloadPackages(_groups, os.fspath(tmp_path))
+        new_groups = rez_pip.download.downloadPackages(
+            _groups, os.fspath(tmp_path), runner
+        )
 
     assert len(new_groups) == len(groups)
     assert sum(len(group.packages) for group in new_groups) == sum(
@@ -113,7 +142,7 @@ def test_download(groups: typing.List[Group], tmp_path: pathlib.Path):
 
     for group in groups:
         for package in group.packages:
-            with open(wheelsMapping[package.name]) as fd:
+            with open(wheelsMapping[package.name], "rb") as fd:
                 content = fd.read()
             assert content == package.content
 
@@ -130,11 +159,11 @@ def test_download(groups: typing.List[Group], tmp_path: pathlib.Path):
     ]
 
 
-def test_download_skip_local(tmp_path: pathlib.Path):
+def test_download_skip_local(tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner):
     """Test that wheels are not downloaded if they are local wheels"""
     groups = [
         rez_pip.pip.PackageGroup[rez_pip.pip.PackageInfo](
-            [
+            (
                 rez_pip.pip.PackageInfo(
                     metadata=rez_pip.pip.Metadata(name="package-a", version="1.0.0"),
                     download_info=rez_pip.pip.DownloadInfo(
@@ -143,8 +172,8 @@ def test_download_skip_local(tmp_path: pathlib.Path):
                     ),
                     is_direct=True,
                     requested=True,
-                )
-            ]
+                ),
+            )
         )
     ]
 
@@ -152,7 +181,7 @@ def test_download_skip_local(tmp_path: pathlib.Path):
 
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet
-        wheels = rez_pip.download.downloadPackages(groups, os.fspath(tmp_path))
+        wheels = rez_pip.download.downloadPackages(groups, os.fspath(tmp_path), runner)
 
     assert not mocked.called
     data = rez_pip.pip.PackageGroup(
@@ -168,7 +197,9 @@ def test_download_skip_local(tmp_path: pathlib.Path):
     assert wheels == [data]
 
 
-def test_download_multiple_packages_with_failure(tmp_path: pathlib.Path):
+def test_download_multiple_packages_with_failure(
+    tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner
+):
     """
     Test that a failure in one package does not prevent other
     packages from being downloaded
@@ -200,10 +231,10 @@ def test_download_multiple_packages_with_failure(tmp_path: pathlib.Path):
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet
         with pytest.raises(RuntimeError):
-            rez_pip.download.downloadPackages(
+            _ = rez_pip.download.downloadPackages(
                 [
                     rez_pip.pip.PackageGroup(
-                        [
+                        (
                             rez_pip.pip.PackageInfo(
                                 metadata=rez_pip.pip.Metadata(
                                     name="package-a", version="1.0.0"
@@ -214,11 +245,11 @@ def test_download_multiple_packages_with_failure(tmp_path: pathlib.Path):
                                 ),
                                 is_direct=True,
                                 requested=True,
-                            )
-                        ]
+                            ),
+                        )
                     ),
                     rez_pip.pip.PackageGroup(
-                        [
+                        (
                             rez_pip.pip.PackageInfo(
                                 metadata=rez_pip.pip.Metadata(
                                     name="package-b", version="1.0.0"
@@ -229,14 +260,15 @@ def test_download_multiple_packages_with_failure(tmp_path: pathlib.Path):
                                 ),
                                 is_direct=True,
                                 requested=True,
-                            )
-                        ]
+                            ),
+                        )
                     ),
                 ],
                 os.fspath(tmp_path),
+                runner,
             )
 
-        # Check that package-a was downloaded even if even if package-b failed.
+        # Check that package-a was downloaded even if package-b failed.
         with open(tmp_path / "package-a") as fd:
             assert fd.read() == "package-a data"
 
@@ -258,39 +290,40 @@ def test_download_multiple_packages_with_failure(tmp_path: pathlib.Path):
         ]
 
 
-def test_download_reuse_if_same_hash(tmp_path: pathlib.Path):
+def test_download_reuse_if_same_hash(
+    tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner
+):
     """Test that wheels are re-used if the sha256 matches"""
     sideEffects = tuple()
     groups = []
 
-    for package in ["package-a", "package-b"]:
-        content = f"{package} data".encode("utf-8")
-
-        hash = hashlib.new("sha256")
-        hash.update(content)
+    for packageName in ["package-a", "package-b"]:
+        package = Package(packageName)
 
         groups.append(
             rez_pip.pip.PackageGroup(
-                [
+                (
                     rez_pip.pip.PackageInfo(
-                        metadata=rez_pip.pip.Metadata(name=package, version="1.0.0"),
+                        metadata=rez_pip.pip.Metadata(
+                            name=packageName, version="1.0.0"
+                        ),
                         download_info=rez_pip.pip.DownloadInfo(
-                            url=f"https://example.com/{package}.whl",
+                            url=f"https://example.com/{packageName}.whl",
                             archive_info=rez_pip.pip.ArchiveInfo(
-                                "hash-a", {"sha256": hash.hexdigest()}
+                                "hash-a", package.hashes
                             ),
                         ),
                         is_direct=True,
                         requested=True,
-                    )
-                ]
+                    ),
+                )
             )
         )
 
         mockedContent = unittest.mock.MagicMock()
         mockedContent.return_value.__aiter__.return_value = [
             [
-                content,
+                package.content,
                 None,
             ]
         ]
@@ -309,7 +342,7 @@ def test_download_reuse_if_same_hash(tmp_path: pathlib.Path):
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet1
 
-        rez_pip.download.downloadPackages(groups, str(tmp_path))
+        rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
 
         assert mocked.call_args_list == [
             unittest.mock.call(
@@ -328,36 +361,36 @@ def test_download_reuse_if_same_hash(tmp_path: pathlib.Path):
             ),
         ]
 
+    sideEffects = tuple()
     groups = []
     # package-b will be re-used
-    for package in ["package-c", "package-b"]:
-        content = f"{package} data".encode("utf-8")
-
-        hash = hashlib.new("sha256")
-        hash.update(content)
+    for packageName in ["package-c", "package-b"]:
+        package = Package(packageName)
 
         groups.append(
             rez_pip.pip.PackageGroup(
-                [
+                (
                     rez_pip.pip.PackageInfo(
-                        metadata=rez_pip.pip.Metadata(name=package, version="1.0.0"),
+                        metadata=rez_pip.pip.Metadata(
+                            name=packageName, version="1.0.0"
+                        ),
                         download_info=rez_pip.pip.DownloadInfo(
-                            url=f"https://example.com/{package}.whl",
+                            url=f"https://example.com/{packageName}.whl",
                             archive_info=rez_pip.pip.ArchiveInfo(
-                                "hash-a", {"sha256": hash.hexdigest()}
+                                "hash-a", package.hashes
                             ),
                         ),
                         is_direct=True,
                         requested=True,
-                    )
-                ]
+                    ),
+                )
             )
         )
 
         mockedContent = unittest.mock.MagicMock()
         mockedContent.return_value.__aiter__.return_value = [
             [
-                content,
+                package.content,
                 None,
             ]
         ]
@@ -376,7 +409,7 @@ def test_download_reuse_if_same_hash(tmp_path: pathlib.Path):
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet2
 
-        wheels = rez_pip.download.downloadPackages(groups, str(tmp_path))
+        wheels = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
 
         assert mocked.call_args_list == [
             unittest.mock.call(
@@ -393,39 +426,40 @@ def test_download_reuse_if_same_hash(tmp_path: pathlib.Path):
     assert len(wheels[1].packages) == 1
 
 
-def test_download_redownload_if_hash_changes(tmp_path: pathlib.Path):
+def test_download_redownload_if_hash_changes(
+    tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner
+) -> None:
     """Test that wheels are re-downloaded if the sha256 changes"""
     sideEffects = tuple()
     groups = []
 
-    for package in ["package-a", "package-b"]:
-        content = f"{package} data".encode("utf-8")
-
-        hash = hashlib.new("sha256")
-        hash.update(content)
+    for packageName in ["package-a", "package-b"]:
+        package = Package(packageName)
 
         groups.append(
             rez_pip.pip.PackageGroup(
-                [
+                (
                     rez_pip.pip.PackageInfo(
-                        metadata=rez_pip.pip.Metadata(name=package, version="1.0.0"),
+                        metadata=rez_pip.pip.Metadata(
+                            name=packageName, version="1.0.0"
+                        ),
                         download_info=rez_pip.pip.DownloadInfo(
-                            url=f"https://example.com/{package}.whl",
+                            url=f"https://example.com/{packageName}.whl",
                             archive_info=rez_pip.pip.ArchiveInfo(
-                                "hash-a", {"sha256": hash.hexdigest()}
+                                "hash-a", package.hashes
                             ),
                         ),
                         is_direct=True,
                         requested=True,
-                    )
-                ]
+                    ),
+                )
             )
         )
 
         mockedContent = unittest.mock.MagicMock()
         mockedContent.return_value.__aiter__.return_value = [
             [
-                content,
+                package.content,
                 None,
             ]
         ]
@@ -444,7 +478,7 @@ def test_download_redownload_if_hash_changes(tmp_path: pathlib.Path):
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet1
 
-        rez_pip.download.downloadPackages(groups, str(tmp_path))
+        rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
 
         assert mocked.call_args_list == [
             unittest.mock.call(
@@ -463,36 +497,36 @@ def test_download_redownload_if_hash_changes(tmp_path: pathlib.Path):
             ),
         ]
 
+    sideEffects = tuple()
     groups = []
-    for package in ["package-a", "package-b"]:
-        content = f"{package} data".encode("utf-8")
+    for packageName in ["package-a", "package-b"]:
+        package = Package(packageName, content=f"{packageName} DATA")
 
         groups.append(
             rez_pip.pip.PackageGroup(
-                [
+                (
                     rez_pip.pip.PackageInfo(
-                        metadata=rez_pip.pip.Metadata(name=package, version="1.0.0"),
+                        metadata=rez_pip.pip.Metadata(
+                            name=packageName, version="1.0.0"
+                        ),
                         download_info=rez_pip.pip.DownloadInfo(
-                            url=f"https://example.com/{package}.whl",
+                            url=f"https://example.com/{packageName}.whl",
                             archive_info=rez_pip.pip.ArchiveInfo(
-                                #
-                                # Bad sha256. This will trigger a new download
-                                #
                                 "hash-a",
-                                {"sha256": "asd"},
+                                package.hashes,
                             ),
                         ),
                         is_direct=True,
                         requested=True,
-                    )
-                ]
+                    ),
+                )
             )
         )
 
         mockedContent = unittest.mock.MagicMock()
         mockedContent.return_value.__aiter__.return_value = [
             [
-                content,
+                package.content,
                 None,
             ]
         ]
@@ -511,7 +545,7 @@ def test_download_redownload_if_hash_changes(tmp_path: pathlib.Path):
     with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
         mocked.return_value = mockedGet2
 
-        wheels = rez_pip.download.downloadPackages(groups, str(tmp_path))
+        wheels = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
 
         assert mocked.call_args_list == [
             unittest.mock.call(
@@ -533,3 +567,186 @@ def test_download_redownload_if_hash_changes(tmp_path: pathlib.Path):
     assert len(wheels) == 2
     assert len(wheels[0].packages) == 1
     assert len(wheels[1].packages) == 1
+
+
+def test_download_unknown_hash_algorithm(
+    tmp_path: pathlib.Path, runner: rez_pip.pip.PipRunner
+) -> None:
+    """Test if the hash algorithm is not known the download fails"""
+    packageName = "package-a"
+    package = Package(packageName)
+
+    groups = [
+        rez_pip.pip.PackageGroup(
+            (
+                rez_pip.pip.PackageInfo(
+                    metadata=rez_pip.pip.Metadata(name=packageName, version="1.0.0"),
+                    download_info=rez_pip.pip.DownloadInfo(
+                        url=f"https://example.com/{packageName}.whl",
+                        archive_info=rez_pip.pip.ArchiveInfo(
+                            "hash-a", {"unknown": "abcdef"}
+                        ),
+                    ),
+                    is_direct=True,
+                    requested=True,
+                ),
+            )
+        )
+    ]
+
+    with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
+        mockedContent = unittest.mock.MagicMock()
+        mockedContent.return_value.__aiter__.return_value = [
+            [
+                package.content,
+                None,
+            ]
+        ]
+        mockedGet = unittest.mock.AsyncMock()
+        mockedGet.__aenter__.return_value = unittest.mock.Mock(
+            headers={"content-length": 100},
+            status=200,
+            content=unittest.mock.Mock(iter_chunks=mockedContent),
+        )
+        mocked.return_value = mockedGet
+
+        with pytest.raises(RuntimeError):
+            _ = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
+
+        assert mocked.call_args_list == [
+            unittest.mock.call(
+                f"https://example.com/{packageName}.whl",
+                headers={
+                    "Content-Type": "application/octet-stream",
+                    "User-Agent": "rez-pip/1.2.3.4.5",
+                },
+            ),
+        ]
+
+
+def test_download_use_pip_if_unauthorized(tmp_path: pathlib.Path) -> None:
+    """Test that pip is called if http status is 401 unauthorized."""
+    packageName = "package-a"
+    package = Package(packageName)
+
+    groups = [
+        rez_pip.pip.PackageGroup(
+            (
+                rez_pip.pip.PackageInfo(
+                    metadata=rez_pip.pip.Metadata(name=packageName, version="1.0.0"),
+                    download_info=rez_pip.pip.DownloadInfo(
+                        url=f"https://example.com/{packageName}.whl",
+                        archive_info=rez_pip.pip.ArchiveInfo("hash-a", package.hashes),
+                    ),
+                    is_direct=True,
+                    requested=True,
+                ),
+            )
+        )
+    ]
+
+    with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
+        mockedGet = unittest.mock.AsyncMock()
+        mockedGet.__aenter__.return_value = unittest.mock.Mock(status=401)
+        mocked.return_value = mockedGet
+
+        runner = unittest.mock.Mock()
+        runner.run = unittest.mock.Mock(
+            side_effect=rez_pip.exceptions.PipError("run should not have been called")
+        )
+        runner.runAsync = unittest.mock.AsyncMock(
+            side_effect=lambda *args, tmp_path=tmp_path, packageName=packageName: (
+                package.write(tmp_path / f"{packageName}.whl")
+            )
+        )
+
+        wheels = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
+
+    assert len(wheels) == 1
+    assert len(wheels[0].packages) == 1
+    assert runner.runAsync.call_count == 1
+    assert runner.runAsync.call_args.args[0] == "download"
+
+
+def test_download_pip_downloads_different_file(tmp_path: pathlib.Path) -> None:
+    """Test that if pip downloads a different file an error is raised."""
+    packageName = "package-a"
+    package = Package(packageName)
+
+    groups = [
+        rez_pip.pip.PackageGroup(
+            (
+                rez_pip.pip.PackageInfo(
+                    metadata=rez_pip.pip.Metadata(name=packageName, version="1.0.0"),
+                    download_info=rez_pip.pip.DownloadInfo(
+                        url=f"https://example.com/{packageName}.whl",
+                        archive_info=rez_pip.pip.ArchiveInfo("hash-a", package.hashes),
+                    ),
+                    is_direct=True,
+                    requested=True,
+                ),
+            )
+        )
+    ]
+
+    with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
+        mockedGet = unittest.mock.AsyncMock()
+        mockedGet.__aenter__.return_value = unittest.mock.Mock(status=401)
+        mocked.return_value = mockedGet
+
+        runner = unittest.mock.Mock()
+        runner.run = unittest.mock.Mock(
+            side_effect=rez_pip.exceptions.PipError("run should not have been called")
+        )
+        runner.runAsync = unittest.mock.AsyncMock(
+            side_effect=lambda *args, tmp_path=tmp_path: package.write(
+                tmp_path / "not-package-a.whl"
+            )
+        )
+
+        with pytest.raises(RuntimeError):
+            _ = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
+
+    assert runner.runAsync.call_count == 1
+    assert runner.runAsync.call_args.args[0] == "download"
+
+
+def test_download_pip_fails(tmp_path: pathlib.Path) -> None:
+    """Test that if pip fails a runtime error is raised."""
+    packageName = "package-a"
+    package = Package(packageName)
+
+    groups = [
+        rez_pip.pip.PackageGroup(
+            (
+                rez_pip.pip.PackageInfo(
+                    metadata=rez_pip.pip.Metadata(name=packageName, version="1.0.0"),
+                    download_info=rez_pip.pip.DownloadInfo(
+                        url=f"https://example.com/{packageName}.whl",
+                        archive_info=rez_pip.pip.ArchiveInfo("hash-a", package.hashes),
+                    ),
+                    is_direct=True,
+                    requested=True,
+                ),
+            )
+        )
+    ]
+
+    with unittest.mock.patch.object(aiohttp.ClientSession, "get") as mocked:
+        mockedGet = unittest.mock.AsyncMock()
+        mockedGet.__aenter__.return_value = unittest.mock.Mock(status=401)
+        mocked.return_value = mockedGet
+
+        runner = unittest.mock.Mock()
+        runner.run = unittest.mock.Mock(
+            side_effect=rez_pip.exceptions.PipError("run should not have been called")
+        )
+        runner.runAsync = unittest.mock.AsyncMock(
+            side_effect=rez_pip.exceptions.PipError("Error from pip")
+        )
+
+        with pytest.raises(RuntimeError):
+            _ = rez_pip.download.downloadPackages(groups, str(tmp_path), runner)
+
+    assert runner.runAsync.call_count == 1
+    assert runner.runAsync.call_args.args[0] == "download"

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -167,11 +167,15 @@ def test_getPackages_no_deps(
             "sha256": index.getWheelHash(expectedPackage.name)
         }
 
+    runner = rez_pip.pip.PipRunner(
+        pythonExecutable=executable,
+        pythonVersion="3.11",
+        pip=rez_pip.pip.getBundledPip(),
+    )
+
     resolvedPackages = rez_pip.pip.getPackages(
+        runner,
         packages,
-        rez_pip.pip.getBundledPip(),
-        "3.11",
-        executable,
         [],
         [],
         ["--index-url", pypi, "-vvv", "--no-deps", "--retries=0"],
@@ -194,11 +198,15 @@ def test_getPackages_with_deps(
     executable, ctx = utils.getPythonRezPackageExecutablePath(pythonRezPackage, rezRepo)
     assert executable is not None
 
+    runner = rez_pip.pip.PipRunner(
+        pythonExecutable=executable,
+        pythonVersion="3.11",
+        pip=rez_pip.pip.getBundledPip(),
+    )
+
     resolvedPackages = rez_pip.pip.getPackages(
+        runner,
         ["package_a"],
-        rez_pip.pip.getBundledPip(),
-        "3.11",
-        executable,
         [],
         [],
         ["--index-url", pypi, "-vvv", "--retries=0"],
@@ -217,12 +225,16 @@ def test_getPackages_error(
 
     packageName = str(uuid.uuid4())
 
+    runner = rez_pip.pip.PipRunner(
+        pythonExecutable=executable,
+        pythonVersion=".".join(str(i) for i in sys.version_info[:2]),
+        pip=rez_pip.pip.getBundledPip(),
+    )
+
     with pytest.raises(rez_pip.exceptions.PipError) as exc:
-        rez_pip.pip.getPackages(
+        _ = rez_pip.pip.getPackages(
+            runner,
             [packageName],
-            rez_pip.pip.getBundledPip(),
-            ".".join(str(i) for i in sys.version_info[:2]),
-            executable,
             [],
             [],
             # Disable retries to speed up the test
@@ -247,7 +259,7 @@ def test_getPackages_error(
 
     assert match is not None
 
-    # Lowercase to avoid discrepencies between C:\ and c:\
+    # Lowercase to avoid discrepancies between C:\ and c:\
     assert (
         "\n".join(capture.get().splitlines()[1:]).lower()
         == f"""


### PR DESCRIPTION
Add a fallback to using pip for downloading if the regular download path get a 401 Unauthorized error.  Addresses ticket https://github.com/JeanChristopheMorinPerso/rez-pip/issues/178.  Should we use pip for all downloads?  Should I add an option to only use pip for downloads.