### PR TITLE
fix: use original package names in dependencies and variants

### DIFF
--- a/src/rez_pip/cli.py
+++ b/src/rez_pip/cli.py
@@ -257,9 +257,9 @@ def _run(args: argparse.Namespace, pipArgs: list[str], pipWorkArea: str) -> None
 
         message = f"Downloaded {downloaded} wheels"
         if foundLocally:
-            message += f"skipped {foundLocally} because they resolved to local files"
+            message += f", skipped {foundLocally} because they resolved to local files"
 
-        _LOG.info(f"[bold]{message}")
+        _LOG.info(f"[bold]{message}.")
 
         with rez_pip.utils.CONSOLE.status(
             f"[bold]Installing wheels into {installedWheelsDir!r}"
@@ -280,11 +280,18 @@ def _run(args: argparse.Namespace, pipArgs: list[str], pipWorkArea: str) -> None
                     group.dists.append(dist)
 
         with rez_pip.utils.CONSOLE.status("[bold]Creating rez packages..."):
+            normalizedPackageNames = {
+                rez_pip.utils.normalizePythonPackageName(dist.name): dist.name
+                for group in packageGroups
+                for dist in group.dists
+            }
+
             for group in packageGroups:
                 rez_pip.rez.createPackage(
                     group,
                     rez.version.Version(pythonVersion),
                     installedWheelsDir,
+                    normalizedPackageNames,
                     prefix=args.prefix,
                     release=args.release,
                 )

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -69,7 +69,7 @@ def createPackage(
     )
 
     rezNames = [
-        rez_pip.utils.pythontDistributionNameToRez(dist.name)
+        rez_pip.utils.pythonDistributionNameToRez(dist.name)
         for dist in packageGroup.dists
     ]
 

--- a/src/rez_pip/rez.py
+++ b/src/rez_pip/rez.py
@@ -59,6 +59,7 @@ def createPackage(
     packageGroup: rez_pip.pip.PackageGroup[rez_pip.pip.DownloadedArtifact],
     pythonVersion: rez.version.Version,
     installedWheelsDir: str,
+    normalizedPackageNames: dict[str, str],
     prefix: str | None = None,
     release: bool = False,
 ) -> None:
@@ -83,7 +84,9 @@ def createPackage(
     metadata: dict[str, typing.Any] = {}
     isPure = True
     for dist in packageGroup.dists:
-        requirements = rez_pip.utils.getRezRequirements(dist, pythonVersion, [])
+        requirements = rez_pip.utils.getRezRequirements(
+            dist, pythonVersion, normalizedPackageNames
+        )
         if not metadata:
             # For now we only use the metadata from the first package. Far from ideal...
             metadata = requirements.metadata

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import re
 import typing
 import logging
 import dataclasses
@@ -36,7 +35,7 @@ class RequirementsDict:
 
 
 def normalizePythonPackageName(name: str) -> str:
-    """Normalize a Python package name according to the packing guidelines.
+    """Normalize a Python package name according to the packging guidelines.
 
     The `Python Packaging User Guide`_ specifies how package names are normalized.
     "The name should be lowercased with all runs of the characters ., -, or _ replaced with a
@@ -600,7 +599,9 @@ def getRezRequirements(
                     to_variant = True
 
             # remap the requirement name
-            req.name = normalizedPackageNames.get(req.name, req.name)
+            req.name = normalizedPackageNames.get(
+                normalizePythonPackageName(req.name), req.name
+            )
 
             # convert the requirement to rez equivalent
             rez_req = str(pythonReqToRezReq(req))

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -12,6 +12,7 @@ import dataclasses
 import rez.system
 import rez.version
 import rich.console
+import packaging.utils
 import packaging.version
 import packaging.specifiers
 import packaging.requirements
@@ -46,7 +47,7 @@ def normalizePythonPackageName(name: str) -> str:
 
     .. _Python Packaging User Guide: https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     """
-    return re.sub(r"[-_.]+", "-", name).lower()
+    return packaging.utils.canonicalize_name(name, validate=False)
 
 
 def pythonDistributionNameToRez(name: str) -> str:

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import re
 import typing
 import logging
 import dataclasses
@@ -41,16 +42,18 @@ def pythonDistributionNameToRez(name: str) -> str:
     name (it would be interpreted as the start of the version).
     Example: my-pkg-1.2 is 'my', version 'pkg-1.2'.
 
-    Python package names can also contain periods.  PEP-0503 states these should
-    be normalized to dash.  Since dashes are important to rez convert periods
-    to underscores.
+    The `Python Packaging User Guide`_ specifies how package names are normalized.
+    "The name should be lowercased with all runs of the characters ., -, or _ replaced with a
+    single - character."  Since dashes are meaningful to rez we will replace with an underscore
+    instead of a dash.
+
 
     :param name: Distribution name to convert.
     :returns: Rez-compatible package name.
+
+    .. _Python Packaging User Guide: https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     """
-    # TODO: Should we fully implement PEP-0503 and substitute multiple period and
-    # TODO: dashes in a row with a single underscore?
-    return name.replace("-", "_").replace(".", "_")
+    return re.sub(r"[-_.]+", "_", name).lower()
 
 
 def pythonDistributionVersionToRez(version: str) -> str:

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -33,7 +33,7 @@ class RequirementsDict:
     metadata: dict[str, typing.Any]
 
 
-def pythontDistributionNameToRez(name: str) -> str:
+def pythonDistributionNameToRez(name: str) -> str:
     """Convert a distribution name to a rez compatible name.
 
     The rez package name can't be simply set to the dist name, because some
@@ -41,10 +41,16 @@ def pythontDistributionNameToRez(name: str) -> str:
     name (it would be interpreted as the start of the version).
     Example: my-pkg-1.2 is 'my', version 'pkg-1.2'.
 
+    Python package names can also contain periods.  PEP-0503 states these should
+    be normalized to dash.  Since dashes are important to rez convert periods
+    to underscores.
+
     :param name: Distribution name to convert.
     :returns: Rez-compatible package name.
     """
-    return name.replace("-", "_")
+    # TODO: Should we fully implement PEP-0503 and substitute multiple period and
+    # TODO: dashes in a row with a single underscore?
+    return name.replace("-", "_").replace(".", "_")
 
 
 def pythonDistributionVersionToRez(version: str) -> str:
@@ -280,7 +286,7 @@ def pythonReqToRezReq(
             f"Ignoring extras requested on {pythonReq!r} - this is not yet supported"
         )
 
-    req = pythontDistributionNameToRez(pythonReq.name)
+    req = pythonDistributionNameToRez(pythonReq.name)
 
     if pythonReq.specifier:
         range_ = pythonSpecifierToRezRequirement(pythonReq.specifier)

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -34,6 +34,21 @@ class RequirementsDict:
     metadata: dict[str, typing.Any]
 
 
+def normalizePythonPackageName(name: str) -> str:
+    """Normalize a Python package name according to the packing guidelines.
+
+    The `Python Packaging User Guide`_ specifies how package names are normalized.
+    "The name should be lowercased with all runs of the characters ., -, or _ replaced with a
+    single - character."
+
+    :param name: The package name to convert.
+    :returns:  The normalized package name.
+
+    .. _Python Packaging User Guide: https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
+    """
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 def pythonDistributionNameToRez(name: str) -> str:
     """Convert a distribution name to a rez compatible name.
 
@@ -42,18 +57,10 @@ def pythonDistributionNameToRez(name: str) -> str:
     name (it would be interpreted as the start of the version).
     Example: my-pkg-1.2 is 'my', version 'pkg-1.2'.
 
-    The `Python Packaging User Guide`_ specifies how package names are normalized.
-    "The name should be lowercased with all runs of the characters ., -, or _ replaced with a
-    single - character."  Since dashes are meaningful to rez we will replace with an underscore
-    instead of a dash.
-
-
     :param name: Distribution name to convert.
     :returns: Rez-compatible package name.
-
-    .. _Python Packaging User Guide: https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization
     """
-    return re.sub(r"[-_.]+", "_", name).lower()
+    return name.replace("-", "_")
 
 
 def pythonDistributionVersionToRez(version: str) -> str:
@@ -484,7 +491,7 @@ def convertMarker(marker: str) -> list[str]:
 def getRezRequirements(
     installedDist: importlib_metadata.Distribution,
     pythonVersion: rez.version.Version,
-    nameCasings: list[str] | None = None,
+    normalizedPackageNames: dict[str, str],
 ) -> RequirementsDict:
     """Get requirements of the given dist, in rez-compatible format.
 
@@ -510,22 +517,18 @@ def getRezRequirements(
 
     :param installedDist: Distribution to convert.
     :param pythonVersion: Python version used to perform the installation.
-    :param nameCasings: A list of pip package names in their correct
-        casings (eg, 'Foo' rather than 'foo'). Any requirement whose name
-        case-insensitive-matches a name in this list, is set to that name.
-        This is needed because pip package names are case insensitive, but
-        rez is case-sensitive. So a package may list a requirement for package
-        'foo', when in fact the package that pip has downloaded is called 'Foo'.
-        Be sure to provide names in PIP format, not REZ format (the pip package
+    :param normalizedPackageNames: A mapping from normalized python package names
+        to the original package name.  Any requirement whose name matches
+        a normalized name is mapped back to the original package name.
+        So a package may list a requirement for package 'foo', when in fact
+        the package that pip has downloaded is called 'Foo'. Be sure to
+        provide package names in PIP format, not REZ format (the pip package
         'foo-bah' will be converted to 'foo_bah' in rez).
     :returns: See example above.
     """
     _system = rez.system.System()
     result_requires: list[str] = []
     result_variant_requires: list[str] = []
-
-    # create cased names lookup
-    name_mapping = {x.lower(): x for x in (nameCasings or [])}
 
     # requirements such as platform, arch, os, and python
     sys_requires: set[str] = set()
@@ -596,9 +599,7 @@ def getRezRequirements(
                     to_variant = True
 
             # remap the requirement name
-            remapped = name_mapping.get(req.name.lower())
-            if remapped:
-                req.name = remapped
+            req.name = normalizedPackageNames.get(req.name, req.name)
 
             # convert the requirement to rez equivalent
             rez_req = str(pythonReqToRezReq(req))

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -35,7 +35,7 @@ class RequirementsDict:
 
 
 def normalizePythonPackageName(name: str) -> str:
-    """Normalize a Python package name according to the packging guidelines.
+    """Normalize a Python package name according to the packaging guidelines.
 
     The `Python Packaging User Guide`_ specifies how package names are normalized.
     "The name should be lowercased with all runs of the characters ., -, or _ replaced with a

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -137,8 +137,8 @@ def test_installs(
     assert code == 0
 
     for path in stdout.strip().split("\n"):
-        assert path.lower().startswith(os.fspath(tmp_path).lower()), (
-            f"{path!r} does not start with {os.fspath(tmp_path)!r}"
-        )
+        assert path.lower().startswith(
+            os.fspath(tmp_path).lower()
+        ), f"{path!r} does not start with {os.fspath(tmp_path)!r}"
 
     assert not stderr

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,15 +75,12 @@ def test_python_packages(pythonRezPackage: str, rezRepo: str):
 
 
 @pytest.mark.parametrize(
-    "packagesToInstall,rezPackages,imports",
-    [[["PySide6"], ["pyside6"], ["PySide6"]]],
-    ids=["PySide6"],
+    "packagesToInstall,imports", [[["PySide6"], ["PySide6"]]], ids=["PySide6"]
 )
 def test_installs(
     pythonRezPackage: str,
     rezRepo: str,
     packagesToInstall: list[str],
-    rezPackages: list[str],
     imports: list[str],
     tmp_path: pathlib.Path,
     capsys: pytest.CaptureFixture,
@@ -118,7 +115,7 @@ def test_installs(
         subprocess.check_call(command, env=env)
 
     ctx = rez.resolved_context.ResolvedContext(
-        rezPackages + [f"python-{pythonRezPackage}"],
+        packagesToInstall + [f"python-{pythonRezPackage}"],
         package_paths=[rezRepo, os.fspath(tmp_path)],
     )
     assert ctx.status == rez.resolved_context.ResolverStatus.solved
@@ -133,7 +130,6 @@ def test_installs(
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        norc=True,
     )
     print(stdout)
     print("****")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -75,12 +75,15 @@ def test_python_packages(pythonRezPackage: str, rezRepo: str):
 
 
 @pytest.mark.parametrize(
-    "packagesToInstall,imports", [[["PySide6"], ["PySide6"]]], ids=["PySide6"]
+    "packagesToInstall,rezPackages,imports",
+    [[["PySide6"], ["pyside6"], ["PySide6"]]],
+    ids=["PySide6"],
 )
 def test_installs(
     pythonRezPackage: str,
     rezRepo: str,
     packagesToInstall: list[str],
+    rezPackages: list[str],
     imports: list[str],
     tmp_path: pathlib.Path,
     capsys: pytest.CaptureFixture,
@@ -115,7 +118,7 @@ def test_installs(
         subprocess.check_call(command, env=env)
 
     ctx = rez.resolved_context.ResolvedContext(
-        packagesToInstall + [f"python-{pythonRezPackage}"],
+        rezPackages + [f"python-{pythonRezPackage}"],
         package_paths=[rezRepo, os.fspath(tmp_path)],
     )
     assert ctx.status == rez.resolved_context.ResolverStatus.solved
@@ -130,6 +133,7 @@ def test_installs(
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        norc=True,
     )
     print(stdout)
     print("****")
@@ -137,8 +141,8 @@ def test_installs(
     assert code == 0
 
     for path in stdout.strip().split("\n"):
-        assert path.lower().startswith(
-            os.fspath(tmp_path).lower()
-        ), f"{path!r} does not start with {os.fspath(tmp_path)!r}"
+        assert path.lower().startswith(os.fspath(tmp_path).lower()), (
+            f"{path!r} does not start with {os.fspath(tmp_path)!r}"
+        )
 
     assert not stderr

--- a/tests/test_rez.py
+++ b/tests/test_rez.py
@@ -93,6 +93,7 @@ def test_createPackage(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path):
             packageGroup,
             rez.version.Version("3.7.0"),
             source,
+            {},
             prefix=repo,
         )
 
@@ -264,7 +265,9 @@ def test_convertMetadata(
     monkeypatch.setattr(
         dist,
         "read_text",
-        lambda x: f"Metadata-Version: 2.0\nName: package_a\nVersion: 1.0.0\n{metadataText}",
+        lambda x: (
+            f"Metadata-Version: 2.0\nName: package_a\nVersion: 1.0.0\n{metadataText}"
+        ),
     )
 
     converted, remaining = rez_pip.rez._convertMetadata(dist)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,15 +21,23 @@ import rez_pip.utils
 #     cls.dist_path = cls.data_path("pip", "installed_distributions")
 
 
-def test_pythonDistributionNameToRez():
-    """ """
-    assert rez_pip.utils.pythonDistributionNameToRez("asd") == "asd"
-    assert rez_pip.utils.pythonDistributionNameToRez("package-name") == "package_name"
-    assert rez_pip.utils.pythonDistributionNameToRez("package.name") == "package_name"
-    assert (
-        rez_pip.utils.pythonDistributionNameToRez("multi-package.name")
-        == "multi_package_name"
-    )
+@pytest.mark.parametrize(
+    "distribution,expected",
+    [
+        ["asd", "asd"],
+        ["multi-separators.package", "multi_separators_package"],
+        # Examples from the Python Packaging User Guide
+        ["friendly-bard", "friendly_bard"],
+        ["Friendly-Bard", "friendly_bard"],
+        ["FRIENDLY-BARD", "friendly_bard"],
+        ["friendly.bard", "friendly_bard"],
+        ["friendly_bard", "friendly_bard"],
+        ["friendly--bard", "friendly_bard"],
+        ["FrIeNdLy-._.-bArD", "friendly_bard"],
+    ],
+)
+def test_pythonDistributionNameToRez(distribution: str, expected: str):
+    assert rez_pip.utils.pythonDistributionNameToRez(distribution) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,10 +21,15 @@ import rez_pip.utils
 #     cls.dist_path = cls.data_path("pip", "installed_distributions")
 
 
-def test_pythontDistributionNameToRez():
+def test_pythonDistributionNameToRez():
     """ """
-    assert rez_pip.utils.pythontDistributionNameToRez("asd") == "asd"
-    assert rez_pip.utils.pythontDistributionNameToRez("package-name") == "package_name"
+    assert rez_pip.utils.pythonDistributionNameToRez("asd") == "asd"
+    assert rez_pip.utils.pythonDistributionNameToRez("package-name") == "package_name"
+    assert rez_pip.utils.pythonDistributionNameToRez("package.name") == "package_name"
+    assert (
+        rez_pip.utils.pythonDistributionNameToRez("multi-package.name")
+        == "multi_package_name"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,22 +22,28 @@ import rez_pip.utils
 
 
 @pytest.mark.parametrize(
-    "distribution,expected",
+    "package,expected",
     [
         ["asd", "asd"],
-        ["multi-separators.package", "multi_separators_package"],
+        ["multi_separators.package", "multi-separators-package"],
         # Examples from the Python Packaging User Guide
-        ["friendly-bard", "friendly_bard"],
-        ["Friendly-Bard", "friendly_bard"],
-        ["FRIENDLY-BARD", "friendly_bard"],
-        ["friendly.bard", "friendly_bard"],
-        ["friendly_bard", "friendly_bard"],
-        ["friendly--bard", "friendly_bard"],
-        ["FrIeNdLy-._.-bArD", "friendly_bard"],
+        ["friendly-bard", "friendly-bard"],
+        ["Friendly-Bard", "friendly-bard"],
+        ["FRIENDLY-BARD", "friendly-bard"],
+        ["friendly.bard", "friendly-bard"],
+        ["friendly_bard", "friendly-bard"],
+        ["friendly--bard", "friendly-bard"],
+        ["FrIeNdLy-._.-bArD", "friendly-bard"],
     ],
 )
-def test_pythonDistributionNameToRez(distribution: str, expected: str):
-    assert rez_pip.utils.pythonDistributionNameToRez(distribution) == expected
+def test_normalizePythonPackageName(package: str, expected: str):
+    assert rez_pip.utils.normalizePythonPackageName(package) == expected
+
+
+def test_pythonDistributionNameToRez():
+    """ """
+    assert rez_pip.utils.pythonDistributionNameToRez("asd") == "asd"
+    assert rez_pip.utils.pythonDistributionNameToRez("package-name") == "package_name"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See https://github.com/JeanChristopheMorinPerso/rez-pip/issues/249