### PR TITLE
fix: convert file urls to correct path on windows

### DIFF
--- a/src/rez_pip/pip.py
+++ b/src/rez_pip/pip.py
@@ -17,6 +17,7 @@ import dataclasses
 import dataclasses_json
 
 import rez_pip.data
+import rez_pip.utils
 import rez_pip.plugins
 import rez_pip.exceptions
 
@@ -104,7 +105,7 @@ class DownloadedArtifact(PackageInfo):
         """Path to the package on disk."""
         if not self.isDownloadRequired():
             # It's a local file, so we can return the URL (without file://)
-            return self.download_info.url[7:]
+            return rez_pip.utils.urlToPathname(self.download_info.url)
 
         return self._localPath
 

--- a/src/rez_pip/utils.py
+++ b/src/rez_pip/utils.py
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
+import os
 import typing
 import logging
 import dataclasses
+import urllib.parse
+import urllib.request
 
 import rez.system
 import rez.version
@@ -650,3 +653,30 @@ def getRezRequirements(
         variant_requires=variant_requires,
         metadata={"is_pure_python": isPure},  # TODO: This is probably useless.
     )
+
+
+def urlToPathname(fileUrl: str) -> str:
+    """Converts a file:// URL with a Windows drive letter or UNC path to a usable path string."""
+
+    # Example URLs: file:///C:/Users/User/file.txt or # file://localhost/Users/User/file.txt
+
+    parsedUrl = urllib.parse.urlparse(fileUrl)
+
+    if parsedUrl.scheme != "file":
+        raise ValueError("URL scheme must be 'file://'")
+
+    # Convert the path to a platform-specific path.  url2pathname handles
+    # removing the leading slash for Windows drive letters.
+    filePath = urllib.request.url2pathname(parsedUrl.path)
+
+    # Handle UNC paths (e.g., file://server/share/file.txt)
+    if parsedUrl.netloc:
+        # For UNC paths, the format should be \\server\share\...
+        # url2pathname handles the path part, we prepend the netloc
+        filePath = (
+            f"\\\\{parsedUrl.netloc}{filePath}"
+            if os.name == "nt"
+            else f"/{parsedUrl.netloc}{filePath}"
+        )
+
+    return filePath

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -79,7 +79,10 @@ def test_DownloadedArtifact(url: str):
 
     assert info.name == "package_a"
     assert info.version == "1.0.0"
-    assert info.path == "/tmp/package_a-1.0.0-py2.py3-none-any.whl"
+    if os.name == "nt":
+        assert info.path == "\\tmp\\package_a-1.0.0-py2.py3-none-any.whl"
+    else:
+        assert info.path == "/tmp/package_a-1.0.0-py2.py3-none-any.whl"
 
 
 def test_getBundledPip():

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -79,10 +79,7 @@ def test_DownloadedArtifact(url: str):
 
     assert info.name == "package_a"
     assert info.version == "1.0.0"
-    if os.name == "nt":
-        assert info.path == "\\tmp\\package_a-1.0.0-py2.py3-none-any.whl"
-    else:
-        assert info.path == "/tmp/package_a-1.0.0-py2.py3-none-any.whl"
+    assert info.path == "/tmp/package_a-1.0.0-py2.py3-none-any.whl"
 
 
 def test_getBundledPip():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import typing
 
 import pytest
@@ -243,3 +244,35 @@ def test_normalizeRequirement(
     assert [str(req) for req in result] == [str(req) for req in expected]
     for index, req in enumerate(result):
         assert req.conditional_extras == conditional_extras[index]
+
+
+def test_urlToPathname() -> None:
+    with pytest.raises(ValueError):
+        _ = rez_pip.utils.urlToPathname("http://example.com")
+
+    if os.name == "nt":
+        assert (
+            rez_pip.utils.urlToPathname("file:///regular/path/to/file")
+            == "\\regular\\path\\to\\file"
+        )
+        assert (
+            rez_pip.utils.urlToPathname("file:///C:/drive/path/to/file")
+            == "C:\\drive\\path\\to\\file"
+        )
+        assert (
+            rez_pip.utils.urlToPathname("file://hostname/unc/path/to/file")
+            == "\\\\hostname\\unc\\path\\to\\file"
+        )
+    else:
+        assert (
+            rez_pip.utils.urlToPathname("file:///regular/path/to/file")
+            == "/regular/path/to/file"
+        )
+        assert (
+            rez_pip.utils.urlToPathname("file:///C:/drive/path/to/file")
+            == "/C:/drive/path/to/file"
+        )
+        assert (
+            rez_pip.utils.urlToPathname("file://hostname/unc/path/to/file")
+            == "/hostname/unc/path/to/file"
+        )


### PR DESCRIPTION
On Windows the leading slash before the drive letter needs to be removed on file urls.

with the new code
```
file:///C:/path/to/file -> C:\path\to\file
```
with the old code
```
file:///C:/path/to/file -> /C:/path/to/file
```