### PR TITLE
build(installer): installer version 1.0 can use full paths in the RECORD file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,9 @@ license = { file="LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
-    "installer>=0.7.0",
+    # Later versions of installer uses absolute paths on Windows.
+    # Use 0.7.0 until workaround can be developed.
+    "installer==0.7.0",
     "aiohttp",
     "packaging>=23.1",
     # 3.3.0 introduces supoprt for entry points plugins.


### PR DESCRIPTION
Until a workaround can be found limit the version of `installer`

`installer` started using absolute paths on Windows when the file is not in the python directory.  This causes rez-pip to install the full path of the temporary directory name.

It was caused by this commit to installer
https://github.com/pypa/installer/commit/2d140de7fc5c11d47d3afa56d1291398fb871053

https://github.com/pypa/installer/issues/260
It seems like puppet had different parts of an install on different drive letters. Maybe we can propose a patch like the issue did and catch the error and then use full paths.